### PR TITLE
Basic benchmark timing support

### DIFF
--- a/src/main/java/evaluation/MultipleClassifierEvaluation.java
+++ b/src/main/java/evaluation/MultipleClassifierEvaluation.java
@@ -14,6 +14,7 @@
  */
 package evaluation;
 
+import com.sun.org.apache.xpath.internal.operations.Mult;
 import evaluation.storage.ClassifierResults;
 import ResultsProcessing.MatlabController;
 import evaluation.storage.ClassifierResultsCollection;
@@ -190,7 +191,7 @@ public class MultipleClassifierEvaluation implements DebugPrinting {
         this.closeMatlabConnectionWhenFinished = closeMatlabConnectionWhenFinished;
         return this;
     }
-    
+
     /**
      * if true, will null the individual prediction info of each ClassifierResults object after stats are found 
      */

--- a/src/main/java/evaluation/PerformanceMetric.java
+++ b/src/main/java/evaluation/PerformanceMetric.java
@@ -46,7 +46,9 @@ public class PerformanceMetric {
     /**
      * currently only used for the pairwise scatter diagrams in the pipeline, 
      * this refers to the descriptor for comparing the scores of a metric between 
-     * classifiers. e.g 'this is {better,worse,slower} than that' 
+     * classifiers
+     *
+     * If the raw value of a is HIGHER than b, then a is {better,worse,slower,faster,etc.} than b
      */
     public String comparisonDescriptor;
     
@@ -86,6 +88,7 @@ public class PerformanceMetric {
     public static PerformanceMetric fromScratchEstimateTime = new PerformanceMetric("FromScratchEstimateTimes", ClassifierResults.GETTER_fromScratchEstimateTimeDoubleMillis, median, min, slower);
     public static PerformanceMetric totalBuildPlusEstimateTime = new PerformanceMetric("TotalBuildPlusEstimateTimes", ClassifierResults.GETTER_totalBuildPlusEstimateTimeDoubleMillis, median, min, slower);
     public static PerformanceMetric additionalTimeForEstimate = new PerformanceMetric("AdditionalTimesForEstimates", ClassifierResults.GETTER_additionalTimeForEstimateDoubleMillis, median, min, slower);
+    public static PerformanceMetric benchmarkTime = new PerformanceMetric("BenchmarkTimes", ClassifierResults.GETTER_benchmarkTime, median, min, slower);
     
     
     public static ArrayList<PerformanceMetric> getAccuracyStatistic() { 

--- a/src/main/java/evaluation/storage/ClassifierResults.java
+++ b/src/main/java/evaluation/storage/ClassifierResults.java
@@ -391,6 +391,7 @@ public class ClassifierResults implements DebugPrinting, Serializable{
     public static final Function<ClassifierResults, Double> GETTER_fromScratchEstimateTimeDoubleMillis = (ClassifierResults cr) -> {return toDoubleMillis(cr.errorEstimateTime, cr.timeUnit);};
     public static final Function<ClassifierResults, Double> GETTER_totalBuildPlusEstimateTimeDoubleMillis = (ClassifierResults cr) -> {return toDoubleMillis(cr.buildPlusEstimateTime, cr.timeUnit);};
     public static final Function<ClassifierResults, Double> GETTER_additionalTimeForEstimateDoubleMillis = (ClassifierResults cr) -> {return toDoubleMillis(cr.buildPlusEstimateTime - cr.buildTime, cr.timeUnit);};
+    public static final Function<ClassifierResults, Double> GETTER_benchmarkTime = (ClassifierResults cr) -> {return toDoubleMillis(cr.benchmarkTime, cr.timeUnit);};
 
     private static double toDoubleMillis(long time, TimeUnit unit) {
         if (time < 0)

--- a/src/main/java/weka_extras/classifiers/ensembles/CAWPE.java
+++ b/src/main/java/weka_extras/classifiers/ensembles/CAWPE.java
@@ -446,7 +446,7 @@ public class CAWPE extends AbstractEnsemble implements TechnicalInformationHandl
      */
     public static void buildCAWPEPaper_AllResultsForFigure3(String writePathBase) throws Exception {
         if (writePathBase == null) 
-            writePathBase = "C:/Temp/MCEUpdateTests/CAWPEReprod08/";
+            writePathBase = "C:/Temp/MCEUpdateTests/CAWPEReprod17/";
         
         //default for unit tests, running on e.g. travis
         String[] dataHeaders = { "UCI", };


### PR DESCRIPTION
Basic (incomplete) benchmark timing support added to stats pipeline. 

"performance metric" to get benchmark times added, methods to write benchmark-corrected timings and the benchmarks themselves to a secondary timings folder, now have timingsRAW and timingsBENCHMARKED. preliminary folder for diagram creation made, not used yet. 

Bug fix to include the benchmark timings in the train files too, previously only was stored in the test files