### PR TITLE
InternalEstimateEvaluator

### DIFF
--- a/src/main/java/evaluation/evaluators/InternalEstimateEvaluator.java
+++ b/src/main/java/evaluation/evaluators/InternalEstimateEvaluator.java
@@ -1,0 +1,52 @@
+package evaluation.evaluators;
+
+import evaluation.storage.ClassifierResults;
+import tsml.classifiers.EnhancedAbstractClassifier;
+import weka.classifiers.Classifier;
+import weka.core.Instances;
+
+/**
+ * A dummy/wrapper evaluator for gathering the internal estimates of classifiers that satisfy
+ * EnhancedAbstractClassifier.classifierAbleToEstimateOwnPerformance(classifier))
+ *
+ * Builds the classifier on the data, and returns the ClassifierResults object that is build internally by the classifier
+ *
+ * Currently, no additional meta info is supplied/forced into the results object by the evaluator, and so it is up to
+ * experimenters and classifier authors to populate any additional meta-info needed/wanted
+ *
+ * @author James Large (james.large@uea.ac.uk)
+ */
+public class InternalEstimateEvaluator extends Evaluator {
+
+    public InternalEstimateEvaluator() {
+        super(0,false,false);
+    }
+    public InternalEstimateEvaluator(int seed, boolean cloneData, boolean setClassMissing) {
+        super(seed,cloneData,setClassMissing);
+    }
+
+    @Override
+    public synchronized ClassifierResults evaluate(Classifier classifier, Instances dataset) throws Exception {
+
+        if (!EnhancedAbstractClassifier.classifierAbleToEstimateOwnPerformance(classifier))
+            throw new IllegalArgumentException("To generate an internal estimate of performance, a classifier must extend " +
+                    "EnhancedAbstractClassifier and have CAN_ESTIMATE_OWN_PERFORMANCE=true. Classifier class passed: " + classifier.getClass().getSimpleName());
+
+        final Instances insts = cloneData ? new Instances(dataset) : dataset;
+
+        EnhancedAbstractClassifier eac = (EnhancedAbstractClassifier) classifier;
+        eac.setEstimateOwnPerformance(true);
+        eac.setSeed(seed);
+        eac.buildClassifier(insts);
+
+        ClassifierResults res = eac.getTrainResults();
+        res.findAllStatsOnce();
+
+        return res;
+    }
+
+    @Override
+    public Evaluator cloneEvaluator() {
+        return new InternalEstimateEvaluator(this.seed, this.cloneData, this.setClassMissing);
+    }
+}

--- a/src/main/java/evaluation/tuning/Tuner.java
+++ b/src/main/java/evaluation/tuning/Tuner.java
@@ -45,9 +45,9 @@ public class Tuner
         implements SaveEachParameter,Checkpointable, TrainTimeContractable {
     
     //Main 3 design choices.
-    private ParameterSearcher searcher = new GridSearcher();
-    private Evaluator evaluator = new CrossValidationEvaluator();
-    private Function<ClassifierResults, Double> evalMetric = ClassifierResults.GETTER_Accuracy;
+    private ParameterSearcher searcher;                      //default = new GridSearcher();
+    private Evaluator evaluator;                             //default = new CrossValidationEvaluator();
+    private Function<ClassifierResults, Double> evalMetric;  //default = ClassifierResults.GETTER_Accuracy;
     
     private ParameterResults bestParaSetAndResults = null;
     
@@ -95,6 +95,14 @@ public class Tuner
     boolean cloneTrainSetForEachParameterEval = false;
 
     public Tuner() { 
+        this(new CrossValidationEvaluator());
+    }
+
+    public Tuner(Evaluator evaluator) {
+        this.searcher = new GridSearcher();
+        this.evaluator = evaluator;
+        this.evalMetric = ClassifierResults.GETTER_Accuracy;
+
         setSeed(0);
     }
 

--- a/src/main/java/machine_learning/classifiers/tuned/TunedClassifier.java
+++ b/src/main/java/machine_learning/classifiers/tuned/TunedClassifier.java
@@ -14,6 +14,8 @@
  */
 package machine_learning.classifiers.tuned;
 
+import evaluation.evaluators.CrossValidationEvaluator;
+import evaluation.evaluators.InternalEstimateEvaluator;
 import evaluation.tuning.ParameterResults;
 import evaluation.tuning.ParameterSet;
 import evaluation.tuning.ParameterSpace;
@@ -80,14 +82,25 @@ public class TunedClassifier extends EnhancedAbstractClassifier
     boolean PS_parameterSplitting = false; //ParameterSplittable
     int PS_paraSetID = -1; //ParameterSplittable
     ////////// end interface variables
-    
-    
+
+    /**
+     * Creates an empty TunedClassifier. Tuner has a default value, however at minimum the classifier and parameter space
+     * shall need to be provided later via set...() methods
+     */
     public TunedClassifier() { 
-        this(null, null, new Tuner()); 
+        this(null, null, new Tuner());
     }
-    
-    public TunedClassifier(AbstractClassifier classifier, ParameterSpace space) { 
-        this(classifier, space, new Tuner());
+
+    /**
+     * If the classifier is able to estimate its own performance while building, the tuner shall default to using that
+     * as the evaluation method. Otherwise defaults to an external 10fold cv
+     */
+    public TunedClassifier(AbstractClassifier classifier, ParameterSpace space) {
+        this(classifier, space,
+            EnhancedAbstractClassifier.classifierAbleToEstimateOwnPerformance(classifier) ?
+                    new Tuner(new InternalEstimateEvaluator()) :
+                    new Tuner(new CrossValidationEvaluator())
+            );
     }
     
     public TunedClassifier(AbstractClassifier classifier, ParameterSpace space, Tuner tuner) { 


### PR DESCRIPTION
Not fully tested, but hopefully straight-forward method of allowing tunedclassifier to use internally-found error estimates to optimise on

If using the two-argument TunedClassifier that takes the classifier and parameterSpace, the tuner will now be set up to use either internal estimates or 10foldcv(as before) dependent on whether the classifier is able to estimate it's own performance

Otherwise the new evaluator needs to be explicitly supplied