### PR TITLE
Fixed an issue with getFoldResults(classifierIndex).

### DIFF
--- a/src/main/java/evaluation/evaluators/MultiSamplingEvaluator.java
+++ b/src/main/java/evaluation/evaluators/MultiSamplingEvaluator.java
@@ -111,7 +111,7 @@ public abstract class MultiSamplingEvaluator extends SamplingEvaluator implement
     
     public ClassifierResults[] getFoldResults(int classifierIndex) {
         if (resultsPerFold != null)
-            return resultsPerFold[0];
+            return resultsPerFold[classifierIndex];
         else
             return null;
     }


### PR DESCRIPTION
Previously the classifierIndex argument was ignored and the function would always return the results for the first classifier.

I suspect this is how it's meant to behave.