### PR TITLE
Fixed an issue with getFoldResults(classifierIndex). 

### DIFF
--- a/src/main/java/evaluation/evaluators/MultiSamplingEvaluator.java
+++ b/src/main/java/evaluation/evaluators/MultiSamplingEvaluator.java
@@ -110,8 +110,8 @@ public abstract class MultiSamplingEvaluator extends SamplingEvaluator implement
     }
     
     public ClassifierResults[] getFoldResults(int classifierIndex) {
-        if (resultsPerFold != null)
-            return resultsPerFold[0];
+        if (resultsPerFold != null && resultsPerFold.length > classifierIndex)
+            return resultsPerFold[classifierIndex];
         else
             return null;
     }


### PR DESCRIPTION
Previously the classifierIndex argument was ignored and the function would always return the results for the first classifier.

Follow up from #353, which targeted the wrong branch.