### PR TITLE
div zero fix for MCE

### DIFF
--- a/src/main/java/evaluation/storage/ClassifierResults.java
+++ b/src/main/java/evaluation/storage/ClassifierResults.java
@@ -529,12 +529,21 @@ public class ClassifierResults implements DebugPrinting, Serializable, MemoryWat
 
     public static final Function<ClassifierResults, Double> GETTER_benchmarkTime = (ClassifierResults cr) -> {return toDoubleMillis(cr.benchmarkTime, cr.timeUnit);};
 
-    public static final Function<ClassifierResults, Double> GETTER_buildTimeDoubleMillisBenchmarked = (ClassifierResults cr) -> {return GETTER_buildTimeDoubleMillis.apply(cr) / GETTER_benchmarkTime.apply(cr);};
-    public static final Function<ClassifierResults, Double> GETTER_totalTestTimeDoubleMillisBenchmarked = (ClassifierResults cr) -> {return GETTER_totalTestTimeDoubleMillis.apply(cr) / GETTER_benchmarkTime.apply(cr);};
-    public static final Function<ClassifierResults, Double> GETTER_avgTestPredTimeDoubleMillisBenchmarked = (ClassifierResults cr) -> {return GETTER_avgTestPredTimeDoubleMillis.apply(cr) / GETTER_benchmarkTime.apply(cr);};
-    public static final Function<ClassifierResults, Double> GETTER_fromScratchEstimateTimeDoubleMillisBenchmarked = (ClassifierResults cr) -> {return GETTER_fromScratchEstimateTimeDoubleMillis.apply(cr) / GETTER_benchmarkTime.apply(cr);};
-    public static final Function<ClassifierResults, Double> GETTER_totalBuildPlusEstimateTimeDoubleMillisBenchmarked = (ClassifierResults cr) -> {return GETTER_totalBuildPlusEstimateTimeDoubleMillis.apply(cr) / GETTER_benchmarkTime.apply(cr);};
-    public static final Function<ClassifierResults, Double> GETTER_additionalTimeForEstimateDoubleMillisBenchmarked = (ClassifierResults cr) -> {return GETTER_additionalTimeForEstimateDoubleMillis.apply(cr) / GETTER_benchmarkTime.apply(cr);};
+    public static final Function<ClassifierResults, Double> GETTER_buildTimeDoubleMillisBenchmarked = (ClassifierResults cr) -> {return divideAvoidInfinity(GETTER_buildTimeDoubleMillis.apply(cr), GETTER_benchmarkTime.apply(cr));};
+    public static final Function<ClassifierResults, Double> GETTER_totalTestTimeDoubleMillisBenchmarked = (ClassifierResults cr) -> {return divideAvoidInfinity(GETTER_totalTestTimeDoubleMillis.apply(cr), GETTER_benchmarkTime.apply(cr));};
+    public static final Function<ClassifierResults, Double> GETTER_avgTestPredTimeDoubleMillisBenchmarked = (ClassifierResults cr) -> {return divideAvoidInfinity(GETTER_avgTestPredTimeDoubleMillis.apply(cr), GETTER_benchmarkTime.apply(cr));};
+    public static final Function<ClassifierResults, Double> GETTER_fromScratchEstimateTimeDoubleMillisBenchmarked = (ClassifierResults cr) -> {return divideAvoidInfinity(GETTER_fromScratchEstimateTimeDoubleMillis.apply(cr), GETTER_benchmarkTime.apply(cr));};
+    public static final Function<ClassifierResults, Double> GETTER_totalBuildPlusEstimateTimeDoubleMillisBenchmarked = (ClassifierResults cr) -> {return divideAvoidInfinity(GETTER_totalBuildPlusEstimateTimeDoubleMillis.apply(cr), GETTER_benchmarkTime.apply(cr));};
+    public static final Function<ClassifierResults, Double> GETTER_additionalTimeForEstimateDoubleMillisBenchmarked = (ClassifierResults cr) -> {return divideAvoidInfinity(GETTER_additionalTimeForEstimateDoubleMillis.apply(cr), GETTER_benchmarkTime.apply(cr));};
+
+    private static double divideAvoidInfinity(double a, double b) {
+        if(b == 0) {
+            // avoid divide by 0 --> infinity
+            return a;
+        } else {
+            return a / b;
+        }
+    }
 
 
     private static double toDoubleMillis(long time, TimeUnit unit) {


### PR DESCRIPTION
ClassifierResults has several getters for the various stats. The timing stats have getters which weight the time by the benchmark time, for example the build time is simply divided by the benchmark time. If, somehow, any of the benchmark times are set to zero a divide-by-zero issue occurs silently in the background. This results in Infinity in the timing stats which eventually get handed over to matlab which consequently explodes trying to parse "Infinity" as a numeric type.

My changes put a simple if/else in the divide operation to check for zero-valued benchmark times skip the weighting (i.e. assume there is no benchmark time, as it is zero, and just use the raw timings). This stops the divide-by-zero problem and fixed matlab complaining about parsing "Infinity".

@James-Large can you look over my changes to make sure they're okay / reproduce analysis results?

**DO NOT MERGE THIS** until reproduced results / verified everything is okay.