### PR TITLE
Tsinst tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ launch.json
 settings.json
 .project
 .classpath
+
+out/

--- a/src/main/java/tsml/data_containers/TSCapabilities.java
+++ b/src/main/java/tsml/data_containers/TSCapabilities.java
@@ -168,7 +168,7 @@ public class TSCapabilities {
 
         @Override
         public boolean test(TimeSeriesInstance inst) {
-            return inst.isEqualLength;
+            return inst.isEqualLength();
         }
     }
     
@@ -180,7 +180,7 @@ public class TSCapabilities {
 
         @Override
         public boolean test(TimeSeriesInstance inst) {
-            return inst.isMultivariate;
+            return inst.isMultivariate();
         }
     }
 
@@ -192,7 +192,7 @@ public class TSCapabilities {
 
         @Override
         public boolean test(TimeSeriesInstance inst) {
-            return inst.hasMissing;
+            return inst.hasMissing();
         }
     }
 
@@ -211,7 +211,7 @@ public class TSCapabilities {
 
         @Override
         public boolean test(TimeSeriesInstance inst) {
-            return inst.minLength >= minL;
+            return inst.getMinLength() >= minL;
         }
     }
     

--- a/src/main/java/tsml/data_containers/TSCapabilities.java
+++ b/src/main/java/tsml/data_containers/TSCapabilities.java
@@ -163,7 +163,7 @@ public class TSCapabilities {
     protected static final class EqualLength extends TSCapability{
         @Override
         public boolean test(TimeSeriesInstances data) {
-            return data.isEqualLength;
+            return data.isEqualLength();
         }
 
         @Override
@@ -175,7 +175,7 @@ public class TSCapabilities {
     protected static final class Multivariate extends TSCapability{
         @Override
         public boolean test(TimeSeriesInstances data) {
-            return data.isMultivariate;
+            return data.isMultivariate();
         }
 
         @Override
@@ -187,7 +187,7 @@ public class TSCapabilities {
     protected static final class MissingValues extends TSCapability{
         @Override
         public boolean test(TimeSeriesInstances data) {
-            return data.hasMissing;
+            return data.hasMissing();
         }
 
         @Override
@@ -206,7 +206,7 @@ public class TSCapabilities {
 
         @Override
         public boolean test(TimeSeriesInstances data) {
-            return data.minLength >= minL;
+            return data.getMinLength() >= minL;
         }
 
         @Override

--- a/src/main/java/tsml/data_containers/TimeSeries.java
+++ b/src/main/java/tsml/data_containers/TimeSeries.java
@@ -287,24 +287,7 @@ public class TimeSeries extends AbstractList<Double> {
     public double[] getVSliceArray(List<Integer> indexesToKeep){
         return getVSliceList(indexesToKeep).stream().mapToDouble(Double::doubleValue).toArray();
     }
-
     
-    /** 
-     * @return int
-     */
-    @Override
-    public int hashCode(){
-        return this.series.hashCode();
-    }
-
-    @Override public boolean equals(final Object o) {
-        if(!(o instanceof TimeSeries)) {
-            return false;
-        }
-        TimeSeries other = (TimeSeries) o;
-        return series.equals(other.series);
-    }
-
     /** 
      * @param args
      */

--- a/src/main/java/tsml/data_containers/TimeSeries.java
+++ b/src/main/java/tsml/data_containers/TimeSeries.java
@@ -170,7 +170,7 @@ public class TimeSeries extends AbstractList<Double> {
     /** 
      * @return double[]
      */
-	public double[] toValuesArray() {
+	public double[] toValueArray() {
 		return getSeries().stream().mapToDouble(Double::doubleValue).toArray();
     }
 

--- a/src/main/java/tsml/data_containers/TimeSeries.java
+++ b/src/main/java/tsml/data_containers/TimeSeries.java
@@ -25,6 +25,13 @@ public class TimeSeries extends AbstractList<Double> {
             series.add(dd);
     }
     
+    public TimeSeries(List<Double> d) {
+        series = new ArrayList<>(d);
+    }
+    
+    public TimeSeries(TimeSeries other) {
+        this(other.series);
+    }    
     
     /** 
      * @param ind

--- a/src/main/java/tsml/data_containers/TimeSeries.java
+++ b/src/main/java/tsml/data_containers/TimeSeries.java
@@ -21,14 +21,8 @@ public class TimeSeries{
 
     public static double DEFAULT_VALUE = Double.NaN;
 
-    /*
-    private double[] series;
-    private double[] indices;
-    */
-
     private List<Double> series;
     private List<Double> indices;
-    MetaData md;
 
 
     public TimeSeries(double[] d){
@@ -123,13 +117,6 @@ public class TimeSeries{
      * @return List<Double>
      */
     public List<Double> getIndices(){ return indices;}
-
-    private class MetaData{
-        String name;
-        Date startDate;
-        double increment;  //Base unit to be ....... 1 day?
-
-    }
 
     
     /** 

--- a/src/main/java/tsml/data_containers/TimeSeries.java
+++ b/src/main/java/tsml/data_containers/TimeSeries.java
@@ -163,13 +163,28 @@ public class TimeSeries extends AbstractList<Double> {
 		return getSeries().stream().mapToDouble(Double::doubleValue).toArray();
     }
 
+    public TimeSeries getVSlice(int[] indices) {
+        return new TimeSeries(getVSliceArray(indices));
+    }
+
+    public TimeSeries getVSlice(List<Integer> indices) {
+	    return getVSlice(indices.stream().mapToInt(Integer::intValue).toArray());
+    }
+
+    public TimeSeries getVSliceComplement(int[] indices) {
+        return new TimeSeries(getVSliceComplementArray(indices));
+    }
+
+    public TimeSeries getVSliceComplement(List<Integer> indices) {
+        return getVSliceComplement(indices.stream().mapToInt(Integer::intValue).toArray());
+    }
     
     /** 
      * this is useful if you want to delete a column/truncate the array, but without modifying the original dataset.
      * @param indexesToRemove
      * @return List<Double>
      */
-    public List<Double> toListWithoutIndexes(List<Integer> indexesToRemove){
+    public List<Double> getVSliceComplementList(List<Integer> indexesToRemove){
         //if the current index isn't in the removal list, then copy across.
         List<Double> out = new ArrayList<>(this.getSeriesLength() - indexesToRemove.size());
         for(int i=0; i<this.getSeriesLength(); ++i){
@@ -179,14 +194,18 @@ public class TimeSeries extends AbstractList<Double> {
 
         return out;
     }
+    
+    public List<Double> getVSliceComplementList(int[] indexesToRemove) {
+        return getVSliceComplementList(Arrays.stream(indexesToRemove).boxed().collect(Collectors.toList()));
+    }
 
     
     /** 
      * @param indexesToKeep
      * @return double[]
      */
-    public double[] toListWithoutIndexes(int[] indexesToKeep){
-        return toArrayWithoutIndexes(Arrays.stream(indexesToKeep).boxed().collect(Collectors.toList()));
+    public double[] getVSliceComplementArray(int[] indexesToKeep){
+        return getVSliceComplementArray(Arrays.stream(indexesToKeep).boxed().collect(Collectors.toList()));
     }
 
     
@@ -194,8 +213,8 @@ public class TimeSeries extends AbstractList<Double> {
      * @param indexesToRemove
      * @return double[]
      */
-    public double[] toArrayWithoutIndexes(List<Integer> indexesToRemove){
-        return toListWithoutIndexes(indexesToRemove).stream().mapToDouble(Double::doubleValue).toArray();
+    public double[] getVSliceComplementArray(List<Integer> indexesToRemove){
+        return getVSliceComplementList(indexesToRemove).stream().mapToDouble(Double::doubleValue).toArray();
     }
     
     
@@ -204,7 +223,7 @@ public class TimeSeries extends AbstractList<Double> {
      * @param indexesToKeep
      * @return List<Double>
      */
-    public List<Double> toListWithIndexes(List<Integer> indexesToKeep){
+    public List<Double> getVSliceList(List<Integer> indexesToKeep){
         //if the current index isn't in the removal list, then copy across.
         List<Double> out = new ArrayList<>(indexesToKeep.size());
         for(int i=0; i<this.getSeriesLength(); ++i){
@@ -214,14 +233,9 @@ public class TimeSeries extends AbstractList<Double> {
 
         return out;
     }
-
     
-    /** 
-     * @param indexesToKeep
-     * @return double[]
-     */
-    public double[] toArrayWithIndexes(int[] indexesToKeep){
-        return toArrayWithIndexes(Arrays.stream(indexesToKeep).boxed().collect(Collectors.toList()));
+    public List<Double> getVSliceList(int[] indexesToKeep) {
+        return getVSliceList(Arrays.stream(indexesToKeep).boxed().collect(Collectors.toList()));
     }
 
     
@@ -229,8 +243,17 @@ public class TimeSeries extends AbstractList<Double> {
      * @param indexesToKeep
      * @return double[]
      */
-    public double[] toArrayWithIndexes(List<Integer> indexesToKeep){
-        return toListWithIndexes(indexesToKeep).stream().mapToDouble(Double::doubleValue).toArray();
+    public double[] getVSliceArray(int[] indexesToKeep){
+        return getVSliceArray(Arrays.stream(indexesToKeep).boxed().collect(Collectors.toList()));
+    }
+
+    
+    /** 
+     * @param indexesToKeep
+     * @return double[]
+     */
+    public double[] getVSliceArray(List<Integer> indexesToKeep){
+        return getVSliceList(indexesToKeep).stream().mapToDouble(Double::doubleValue).toArray();
     }
 
     

--- a/src/main/java/tsml/data_containers/TimeSeries.java
+++ b/src/main/java/tsml/data_containers/TimeSeries.java
@@ -13,7 +13,7 @@ import java.util.stream.DoubleStream;
  * */
 public class TimeSeries extends AbstractList<Double> {
 
-    public static double DEFAULT_VALUE = Double.NaN;
+    public final static double DEFAULT_VALUE = Double.NaN;
 
     private List<Double> series;
     private List<Double> indices;

--- a/src/main/java/tsml/data_containers/TimeSeries.java
+++ b/src/main/java/tsml/data_containers/TimeSeries.java
@@ -163,6 +163,10 @@ public class TimeSeries extends AbstractList<Double> {
         throw new UnsupportedOperationException("time series are not mutable.");
     }
 
+    @Override public Double remove(final int i) {
+        throw new UnsupportedOperationException("time series are not mutable.");
+    }
+
     /** 
      * @return double[]
      */

--- a/src/main/java/tsml/data_containers/TimeSeries.java
+++ b/src/main/java/tsml/data_containers/TimeSeries.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
  * */
 public class TimeSeries{
 
-    public static double defaultValue = Double.NaN;
+    public static double DEFAULT_VALUE = Double.NaN;
 
     /*
     private double[] series;
@@ -82,7 +82,7 @@ public class TimeSeries{
      * @return double
      */
     public double getOrDefault(int i){
-        return hasValidValueAt(i) ? get(i) : defaultValue;
+        return hasValidValueAt(i) ? get(i) : DEFAULT_VALUE;
     }
 
     

--- a/src/main/java/tsml/data_containers/TimeSeries.java
+++ b/src/main/java/tsml/data_containers/TimeSeries.java
@@ -177,11 +177,19 @@ public class TimeSeries extends AbstractList<Double> {
     public TimeSeries getVSlice(int[] indices) {
         return new TimeSeries(getVSliceArray(indices));
     }
+    
+    public TimeSeries getVSlice(int index) {
+	    return getVSlice(new int[] {index});
+    }
 
     public TimeSeries getVSlice(List<Integer> indices) {
 	    return getVSlice(indices.stream().mapToInt(Integer::intValue).toArray());
     }
 
+    public TimeSeries getVSliceComplement(int index) {
+	    return getVSliceComplement(new int[] {index});
+    }
+    
     public TimeSeries getVSliceComplement(int[] indices) {
         return new TimeSeries(getVSliceComplementArray(indices));
     }
@@ -210,6 +218,9 @@ public class TimeSeries extends AbstractList<Double> {
         return getVSliceComplementList(Arrays.stream(indexesToRemove).boxed().collect(Collectors.toList()));
     }
 
+    public List<Double> getVSliceComponentList(int index) {
+        return getVSlice(new int[] {index});
+    }
     
     /** 
      * @param indexesToKeep
@@ -228,6 +239,9 @@ public class TimeSeries extends AbstractList<Double> {
         return getVSliceComplementList(indexesToRemove).stream().mapToDouble(Double::doubleValue).toArray();
     }
     
+    public double[] getVSliceComplementArray(int index) {
+        return getVSliceComplementArray(new int[] {index});
+    }
     
     /** 
      * this is useful if you want to slice a column/truncate the array, but without modifying the original dataset.
@@ -248,7 +262,14 @@ public class TimeSeries extends AbstractList<Double> {
     public List<Double> getVSliceList(int[] indexesToKeep) {
         return getVSliceList(Arrays.stream(indexesToKeep).boxed().collect(Collectors.toList()));
     }
+    
+    public List<Double> getVSliceList(int index) {
+        return getVSliceList(new int[] {index});
+    }
 
+    public double[] getVSliceArray(int index) {
+        return getVSliceArray(new int[] {index});
+    }
     
     /** 
      * @param indexesToKeep

--- a/src/main/java/tsml/data_containers/TimeSeries.java
+++ b/src/main/java/tsml/data_containers/TimeSeries.java
@@ -242,8 +242,14 @@ public class TimeSeries extends AbstractList<Double> {
         return this.series.hashCode();
     }
 
+    @Override public boolean equals(final Object o) {
+        if(!(o instanceof TimeSeries)) {
+            return false;
+        }
+        TimeSeries other = (TimeSeries) o;
+        return series.equals(other.series);
+    }
 
-    
     /** 
      * @param args
      */

--- a/src/main/java/tsml/data_containers/TimeSeries.java
+++ b/src/main/java/tsml/data_containers/TimeSeries.java
@@ -1,14 +1,8 @@
 package tsml.data_containers;
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Date;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
-import java.util.stream.Stream;
 
 /**
  * Class to store a time series. The series can have different indices (time stamps) and store missing values (NaN).
@@ -17,7 +11,7 @@ import java.util.stream.Stream;
  * Hopefully most of this can be encapsulated, so if the data has equal increments then indices is null and the user
 
  * */
-public class TimeSeries{
+public class TimeSeries extends AbstractList<Double> {
 
     public static double DEFAULT_VALUE = Double.NaN;
 
@@ -66,24 +60,32 @@ public class TimeSeries{
      * @param i
      * @return double
      */
-    public double get(int i){
+    public double getValue(int i){
         return series.get(i);
     }
 
+    /**
+     * Gets a value at a specific index in the time series. This method conducts unboxing so use getValue if you care about performance.
+     * @param i
+     * @return
+     */
+    public Double get(int i) {
+        return series.get(i);
+    }
     
     /** 
      * @param i
      * @return double
      */
     public double getOrDefault(int i){
-        return hasValidValueAt(i) ? get(i) : DEFAULT_VALUE;
+        return hasValidValueAt(i) ? getValue(i) : DEFAULT_VALUE;
     }
 
     
     /** 
      * @return DoubleStream
      */
-    public DoubleStream stream(){
+    public DoubleStream streamValues(){
         return series.stream().mapToDouble(Double::doubleValue);
     }
 
@@ -133,12 +135,31 @@ public class TimeSeries{
         return sb.toString();
     }
 
-    
+
+    /**
+     * Get the length of the series.
+     * @return
+     */
+    @Override public int size() {
+        return getSeriesLength();
+    }
+
+    @Override public void add(final int i, final Double aDouble) {
+        throw new UnsupportedOperationException("time series are not mutable.");
+    }
+
+    @Override public Double set(final int i, final Double aDouble) {
+        throw new UnsupportedOperationException("time series are not mutable.");
+    }
+
+    @Override public void clear() {
+        throw new UnsupportedOperationException("time series are not mutable.");
+    }
+
     /** 
      * @return double[]
      */
-
-	public double[] toArray() {
+	public double[] toValuesArray() {
 		return getSeries().stream().mapToDouble(Double::doubleValue).toArray();
     }
 
@@ -148,7 +169,7 @@ public class TimeSeries{
      * @param indexesToRemove
      * @return List<Double>
      */
-public List<Double> toListWithoutIndexes(List<Integer> indexesToRemove){
+    public List<Double> toListWithoutIndexes(List<Integer> indexesToRemove){
         //if the current index isn't in the removal list, then copy across.
         List<Double> out = new ArrayList<>(this.getSeriesLength() - indexesToRemove.size());
         for(int i=0; i<this.getSeriesLength(); ++i){
@@ -229,6 +250,5 @@ public List<Double> toListWithoutIndexes(List<Integer> indexesToRemove){
     public static void main(String[] args) {
         TimeSeries ts = new TimeSeries(new double[]{1,2,3,4}) ;
     }
-
 
 }

--- a/src/main/java/tsml/data_containers/TimeSeriesInstance.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstance.java
@@ -172,7 +172,6 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
     public int getLabelIndex(){
         return labelIndex;
     }
-
     
     /** 
      * @param index
@@ -186,7 +185,6 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
 
         return out;
     }
-
     
     /** 
      * @param index
@@ -201,7 +199,6 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
 
         return out;
     }
-
     
     /** 
      * @param indexesToKeep
@@ -256,6 +253,10 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
     
     public TimeSeriesInstance getVSlice(int[] indexesToKeep) {
         return getVSlice(Arrays.stream(indexesToKeep).boxed().collect(Collectors.toList()));
+    }
+    
+    public TimeSeriesInstance getVSlice(int index) {
+        return getVSlice(new int[] {index});
     }
 
 
@@ -330,6 +331,10 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
     
     public TimeSeriesInstance getHSlice(int[] dimensionsToKeep) {
         return getHSlice(Arrays.stream(dimensionsToKeep).boxed().collect(Collectors.toList()));
+    }
+    
+    public TimeSeriesInstance getHSlice(int index) {
+        return getHSlice(new int[] {index});
     }
 
     

--- a/src/main/java/tsml/data_containers/TimeSeriesInstance.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstance.java
@@ -139,8 +139,7 @@ public class TimeSeriesInstance implements Iterable<TimeSeries> {
     private void calculateIfMissing() {
         // if any of the series have a NaN value, across all dimensions then this is
         // true.
-        hasMissing = seriesDimensions.stream().map(e -> e.stream().anyMatch(Double::isNaN))
-                .anyMatch(Boolean::booleanValue);
+        hasMissing = seriesDimensions.stream().anyMatch(e -> e.streamValues().anyMatch(Double::isNaN));
     };
 
     
@@ -167,7 +166,7 @@ public class TimeSeriesInstance implements Iterable<TimeSeries> {
     public List<Double> getSingleVSliceList(int index){
         List<Double> out = new ArrayList<>(getNumDimensions());
         for(TimeSeries ts : seriesDimensions){
-            out.add(ts.get(index));
+            out.add(ts.getValue(index));
         }
 
         return out;
@@ -182,7 +181,7 @@ public class TimeSeriesInstance implements Iterable<TimeSeries> {
         double[] out = new double[getNumDimensions()];
         int i=0;
         for(TimeSeries ts : seriesDimensions){
-            out[i++] = ts.get(index);
+            out[i++] = ts.getValue(index);
         }
 
         return out;
@@ -252,7 +251,7 @@ public class TimeSeriesInstance implements Iterable<TimeSeries> {
      * @return double[]
      */
     public double[] getSingleHSliceArray(int dim){
-        return seriesDimensions.get(dim).toArray();
+        return seriesDimensions.get(dim).toValuesArray();
     }
 
     
@@ -296,7 +295,7 @@ public class TimeSeriesInstance implements Iterable<TimeSeries> {
         double[][] out = new double[dimensionsToKeep.size()][];
         int i=0;
         for(Integer dim : dimensionsToKeep){
-            out[i++] = seriesDimensions.get(dim).toArray();
+            out[i++] = seriesDimensions.get(dim).toValuesArray();
         }
 
         return out;
@@ -336,7 +335,7 @@ public class TimeSeriesInstance implements Iterable<TimeSeries> {
         double[][] output = new double[this.seriesDimensions.size()][];
         for (int i=0; i<output.length; ++i){
              //clone the data so the underlying representation can't be modified
-            output[i] = seriesDimensions.get(i).toArray();
+            output[i] = seriesDimensions.get(i).toValuesArray();
         }
         return output;
     }

--- a/src/main/java/tsml/data_containers/TimeSeriesInstance.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstance.java
@@ -19,13 +19,25 @@ import java.util.stream.IntStream;
 public class TimeSeriesInstance implements Iterable<TimeSeries> {
 
     /* Meta Information */
-    boolean isMultivariate;
-    boolean isEquallySpaced;
-    boolean hasMissing;
-    boolean isEqualLength;
+    private boolean isMultivariate;
+    private boolean isEquallySpaced;
+    private boolean hasMissing;
+    private boolean isEqualLength;
 
-    int minLength;
-    int maxLength;
+    private int minLength;
+    private int maxLength;
+
+    public boolean isMultivariate() {
+        return isMultivariate;
+    }
+
+    public boolean isEquallySpaced() {
+        return isEquallySpaced;
+    }
+
+    public boolean hasMissing() {
+        return hasMissing;
+    }
 
     /** 
      * @return boolean
@@ -53,9 +65,9 @@ public class TimeSeriesInstance implements Iterable<TimeSeries> {
 
 
     /* Data */
-    List<TimeSeries> seriesDimensions;
-    int classLabelIndex;
-    double targetValue;
+    private List<TimeSeries> seriesDimensions;
+    private int classLabelIndex;
+    private double targetValue;
 
     // this ctor can be made way more sophisticated.
     public TimeSeriesInstance(List<List<Double>> series, Double value) {
@@ -368,6 +380,11 @@ public class TimeSeriesInstance implements Iterable<TimeSeries> {
 	}
 
 
+    public int getClassLabelIndex() {
+        return classLabelIndex;
+    }
 
-
+    public double getTargetValue() {
+        return targetValue;
+    }
 }

--- a/src/main/java/tsml/data_containers/TimeSeriesInstance.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstance.java
@@ -128,6 +128,14 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
  
         dataChecks();
     }
+    
+    private TimeSeriesInstance(double[][] data, TimeSeriesInstance other) {
+        this(data);
+        classLabelIndex = other.classLabelIndex;
+        targetValue = other.targetValue;
+        
+        dataChecks();
+    }
 
     private void dataChecks(){
         calculateIfMultivariate();
@@ -172,7 +180,7 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
      * @param index
      * @return List<Double>
      */
-    public List<Double> getSingleVSliceList(int index){
+    public List<Double> getVSliceList(int index){
         List<Double> out = new ArrayList<>(getNumDimensions());
         for(TimeSeries ts : seriesDimensions){
             out.add(ts.getValue(index));
@@ -186,7 +194,7 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
      * @param index
      * @return double[]
      */
-    public double[] getSingleVSliceArray(int index){
+    public double[] getVSliceArray(int index){
         double[] out = new double[getNumDimensions()];
         int i=0;
         for(TimeSeries ts : seriesDimensions){
@@ -243,6 +251,14 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
 
         return out;
     }
+    
+    public TimeSeriesInstance getVSlice(List<Integer> indexesToKeep) {
+        return new TimeSeriesInstance(getVSliceArray(indexesToKeep), this);
+    }
+    
+    public TimeSeriesInstance getVSlice(int[] indexesToKeep) {
+        return getVSlice(Arrays.stream(indexesToKeep).boxed().collect(Collectors.toList()));
+    }
 
 
     
@@ -250,7 +266,7 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
      * @param dim
      * @return List<Double>
      */
-    public List<Double> getSingleHSliceList(int dim){
+    public List<Double> getHSliceList(int dim){
         return seriesDimensions.get(dim).getSeries();
     }
 
@@ -259,8 +275,8 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
      * @param dim
      * @return double[]
      */
-    public double[] getSingleHSliceArray(int dim){
-        return seriesDimensions.get(dim).toValuesArray();
+    public double[] getHSliceArray(int dim){
+        return seriesDimensions.get(dim).toValueArray();
     }
 
     
@@ -304,10 +320,18 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
         double[][] out = new double[dimensionsToKeep.size()][];
         int i=0;
         for(Integer dim : dimensionsToKeep){
-            out[i++] = seriesDimensions.get(dim).toValuesArray();
+            out[i++] = seriesDimensions.get(dim).toValueArray();
         }
 
         return out;
+    }
+    
+    public TimeSeriesInstance getHSlice(List<Integer> dimensionsToKeep) {
+        return new TimeSeriesInstance(getHSliceArray(dimensionsToKeep), this);
+    }
+    
+    public TimeSeriesInstance getHSlice(int[] dimensionsToKeep) {
+        return getHSlice(Arrays.stream(dimensionsToKeep).boxed().collect(Collectors.toList()));
     }
 
     
@@ -326,16 +350,6 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
 
         return sb.toString();
     }
-
-    
-    /** 
-     * @return Iterator<TimeSeries>
-     */
-    @Override
-    public Iterator<TimeSeries> iterator() {
-        return seriesDimensions.iterator();
-    }
-
     
     /** 
      * @return double[][]
@@ -344,7 +358,7 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
         double[][] output = new double[this.seriesDimensions.size()][];
         for (int i=0; i<output.length; ++i){
              //clone the data so the underlying representation can't be modified
-            output[i] = seriesDimensions.get(i).toValuesArray();
+            output[i] = seriesDimensions.get(i).toValueArray();
         }
         return output;
     }

--- a/src/main/java/tsml/data_containers/TimeSeriesInstance.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstance.java
@@ -86,9 +86,7 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
     public TimeSeriesInstance(int labelIndex, List<TimeSeries> series) {
         seriesDimensions = new ArrayList<TimeSeries>();
 
-        for (TimeSeries ts : series) {
-            seriesDimensions.add(ts);
-        }
+        seriesDimensions.addAll(series);
 
         this.labelIndex = labelIndex; 
         dataChecks();
@@ -148,8 +146,8 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
     }
 
 	private void calculateLengthBounds() {
-        minLength = seriesDimensions.stream().mapToInt(e -> e.getSeriesLength()).min().getAsInt();
-        maxLength = seriesDimensions.stream().mapToInt(e -> e.getSeriesLength()).max().getAsInt();
+        minLength = seriesDimensions.stream().mapToInt(TimeSeries::getSeriesLength).min().getAsInt();
+        maxLength = seriesDimensions.stream().mapToInt(TimeSeries::getSeriesLength).max().getAsInt();
         isEqualLength = minLength == maxLength;
     }
 

--- a/src/main/java/tsml/data_containers/TimeSeriesInstance.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstance.java
@@ -1,9 +1,6 @@
 package tsml.data_containers;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -16,7 +13,7 @@ import java.util.stream.IntStream;
  * creation, mutability can break this
  */
 
-public class TimeSeriesInstance implements Iterable<TimeSeries> {
+public class TimeSeriesInstance extends AbstractList<TimeSeries> {
 
     /* Meta Information */
     private boolean isMultivariate;
@@ -386,5 +383,25 @@ public class TimeSeriesInstance implements Iterable<TimeSeries> {
 
     public double getTargetValue() {
         return targetValue;
+    }
+
+    @Override public int size() {
+        return getNumDimensions();
+    }
+
+    @Override public void add(final int i, final TimeSeries doubles) {
+        throw new UnsupportedOperationException("TimeSeriesInstance not mutable");
+    }
+
+    @Override public TimeSeries set(final int i, final TimeSeries doubles) {
+        throw new UnsupportedOperationException("TimeSeriesInstance not mutable");
+    }
+
+    @Override public void clear() {
+        throw new UnsupportedOperationException("TimeSeriesInstance not mutable");
+    }
+
+    @Override public TimeSeries remove(final int i) {
+        throw new UnsupportedOperationException("TimeSeriesInstance not mutable");
     }
 }

--- a/src/main/java/tsml/data_containers/TimeSeriesInstance.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstance.java
@@ -204,7 +204,7 @@ public class TimeSeriesInstance implements Iterable<TimeSeries> {
     public List<List<Double>> getVSliceList(List<Integer> indexesToKeep){
         List<List<Double>> out = new ArrayList<>(getNumDimensions());
         for(TimeSeries ts : seriesDimensions){
-            out.add(ts.toListWithIndexes(indexesToKeep));
+            out.add(ts.getVSliceList(indexesToKeep));
         }
 
         return out;
@@ -229,7 +229,7 @@ public class TimeSeriesInstance implements Iterable<TimeSeries> {
         double[][] out = new double[getNumDimensions()][];
         int i=0;
         for(TimeSeries ts : seriesDimensions){
-            out[i++] = ts.toArrayWithIndexes(indexesToKeep);
+            out[i++] = ts.getVSliceArray(indexesToKeep);
         }
 
         return out;

--- a/src/main/java/tsml/data_containers/TimeSeriesInstance.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstance.java
@@ -17,7 +17,7 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
 
     /* Meta Information */
     private boolean isMultivariate;
-    private boolean isEquallySpaced;
+    private boolean isEquallySpaced; // todo compute whether timestamps are equally spaced
     private boolean hasMissing;
     private boolean isEqualLength;
 
@@ -63,7 +63,7 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
 
     /* Data */
     private List<TimeSeries> seriesDimensions;
-    private int classLabelIndex;
+    private int labelIndex;
     private double targetValue;
 
     // this ctor can be made way more sophisticated.
@@ -71,7 +71,7 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
         this(series);
 
         //could be an index, or it could be regression target
-        classLabelIndex = value.intValue();
+        labelIndex = value.intValue();
         targetValue = value;
     }
 
@@ -79,7 +79,7 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
     public TimeSeriesInstance(List<List<Double>> series, int label) {
         this(series);
 
-        classLabelIndex = label;
+        labelIndex = label;
     }
 
     //do the ctor this way round to avoid erasure problems :(
@@ -90,7 +90,7 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
             seriesDimensions.add(ts);
         }
 
-        classLabelIndex = labelIndex; 
+        this.labelIndex = labelIndex; 
         dataChecks();
     }
 
@@ -124,14 +124,14 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
             seriesDimensions.add(new TimeSeries(in));
         }
 
-        classLabelIndex = labelIndex;
+        this.labelIndex = labelIndex;
  
         dataChecks();
     }
     
     private TimeSeriesInstance(double[][] data, TimeSeriesInstance other) {
         this(data);
-        classLabelIndex = other.classLabelIndex;
+        labelIndex = other.labelIndex;
         targetValue = other.targetValue;
         
         dataChecks();
@@ -172,7 +172,7 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
      * @return int
      */
     public int getLabelIndex(){
-        return classLabelIndex;
+        return labelIndex;
     }
 
     
@@ -342,7 +342,7 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
     public String toString() {
         StringBuilder sb = new StringBuilder();
 
-        sb.append("Num Dimensions: ").append(getNumDimensions()).append(" Class Label Index: ").append(classLabelIndex);
+        sb.append("Num Dimensions: ").append(getNumDimensions()).append(" Class Label Index: ").append(labelIndex);
         for (TimeSeries ts : seriesDimensions) {
             sb.append(System.lineSeparator());
             sb.append(ts.toString());
@@ -389,11 +389,7 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
     public TimeSeries get(int i) {
         return this.seriesDimensions.get(i);
 	}
-
-
-    public int getClassLabelIndex() {
-        return classLabelIndex;
-    }
+	
 
     public double getTargetValue() {
         return targetValue;

--- a/src/main/java/tsml/data_containers/TimeSeriesInstance.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstance.java
@@ -373,17 +373,6 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
     public double[][] toTransposedArray(){
         return this.getVSliceArray(IntStream.range(0, maxLength).toArray());
     }
-
-
-    
-    /** 
-     * @return int
-     */
-    @Override
-    public int hashCode(){
-        return this.seriesDimensions.hashCode();
-    }
-
 	
     /** 
      * @param i
@@ -417,4 +406,5 @@ public class TimeSeriesInstance extends AbstractList<TimeSeries> {
     @Override public TimeSeries remove(final int i) {
         throw new UnsupportedOperationException("TimeSeriesInstance not mutable");
     }
+
 }

--- a/src/main/java/tsml/data_containers/TimeSeriesInstances.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstances.java
@@ -323,16 +323,6 @@ public class TimeSeriesInstances extends AbstractList<TimeSeriesInstance> {
 
         return sb.toString();
     }
-
-    
-    /** 
-     * @return Iterator<TimeSeriesInstance>
-     */
-    @Override
-    public Iterator<TimeSeriesInstance> iterator() {
-        return seriesCollection.iterator();
-    }
-
     
     /** 
      * @return double[][][]

--- a/src/main/java/tsml/data_containers/TimeSeriesInstances.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstances.java
@@ -463,7 +463,7 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
         int i=0;
         for(TimeSeriesInstance inst : seriesCollection){
             // if the index isn't always valid, populate with NaN values.
-            out[i++] = inst.getSingleHSliceArray(dim);
+            out[i++] = inst.getHSliceArray(dim);
         }
         return out;
     }

--- a/src/main/java/tsml/data_containers/TimeSeriesInstances.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstances.java
@@ -119,31 +119,6 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
     public void setProblemName(String problemName) {
         this.problemName = problemName;
     }
-
-    
-    /** 
-     * @param isEquallySpaced
-     */
-    public void setEquallySpaced(boolean isEquallySpaced) {
-        this.isEquallySpaced = isEquallySpaced;
-    }
-
-    
-    /** 
-     * @return boolean
-     */
-    public boolean isHasTimeStamps() {
-        return hasTimeStamps;
-    }
-
-    
-    /** 
-     * @param hasTimeStamps
-     */
-    public void setHasTimeStamps(boolean hasTimeStamps) {
-        this.hasTimeStamps = hasTimeStamps;
-    }
-
     
     /** 
      * @return String

--- a/src/main/java/tsml/data_containers/TimeSeriesInstances.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstances.java
@@ -288,21 +288,21 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
 
     
     /** 
-     * @param new_series
+     * @param newSeries
      */
-    public void add(final TimeSeriesInstance new_series) {
-        seriesCollection.add(new_series);
+    public void add(final TimeSeriesInstance newSeries) {
+        seriesCollection.add(newSeries);
 
         //guard for if we're going to force update classCounts after.
-        if(classCounts != null && new_series.getLabelIndex() < classCounts.length)
-            classCounts[new_series.getLabelIndex()]++;
+        if(classCounts != null && newSeries.getLabelIndex() < classCounts.length)
+            classCounts[newSeries.getLabelIndex()]++;
 
-        minLength = Math.min(new_series.getMinLength(), minLength);
-        maxLength = Math.max(new_series.getMaxLength(), maxLength);
-        maxNumDimensions = Math.max(new_series.getNumDimensions(), maxNumDimensions);
-        hasMissing |= new_series.hasMissing();
+        minLength = Math.min(newSeries.getMinLength(), minLength);
+        maxLength = Math.max(newSeries.getMaxLength(), maxLength);
+        maxNumDimensions = Math.max(newSeries.getNumDimensions(), maxNumDimensions);
+        hasMissing |= newSeries.hasMissing();
         isEqualLength = minLength == maxLength;
-        isMultivariate |= new_series.isMultivariate();
+        isMultivariate |= newSeries.isMultivariate();
     }
 
     

--- a/src/main/java/tsml/data_containers/TimeSeriesInstances.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstances.java
@@ -249,7 +249,7 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
     private void calculateClassCounts() {
         classCounts = new int[classLabels.length];
         for(TimeSeriesInstance inst : seriesCollection){
-            classCounts[inst.getClassLabelIndex()]++;
+            classCounts[inst.getLabelIndex()]++;
         }
     }
 
@@ -317,8 +317,8 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
         seriesCollection.add(new_series);
 
         //guard for if we're going to force update classCounts after.
-        if(classCounts != null && new_series.getClassLabelIndex() < classCounts.length)
-            classCounts[new_series.getClassLabelIndex()]++;
+        if(classCounts != null && new_series.getLabelIndex() < classCounts.length)
+            classCounts[new_series.getLabelIndex()]++;
 
         minLength = Math.min(new_series.getMinLength(), minLength);
         maxLength = Math.max(new_series.getMaxLength(), maxLength);
@@ -382,7 +382,7 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
         int[] out = new int[numInstances()];
         int index=0;
         for(TimeSeriesInstance inst : seriesCollection){
-            out[index++] = inst.getClassLabelIndex();
+            out[index++] = inst.getLabelIndex();
         }
         return out;
     }

--- a/src/main/java/tsml/data_containers/TimeSeriesInstances.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstances.java
@@ -2,7 +2,6 @@ package tsml.data_containers;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -400,7 +399,7 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
         for(TimeSeriesInstance inst : seriesCollection){
             for(TimeSeries ts : inst)
                 // if the index isn't always valid, populate with NaN values.
-                out[i++] = ts.hasValidValueAt(index) ? ts.get(index) : Double.NaN;
+                out[i++] = ts.hasValidValueAt(index) ? ts.getValue(index) : Double.NaN;
         }
 
         return out;

--- a/src/main/java/tsml/data_containers/TimeSeriesInstances.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstances.java
@@ -15,22 +15,24 @@ import java.util.stream.Collectors;
 public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
 
     /* Meta Information */
-    String description;
-    String problemName;
-    boolean isEquallySpaced = true;
-    boolean hasMissing;
-    boolean isEqualLength;
+    private String description;
+    private String problemName;
+    private boolean isEquallySpaced = true;
+    private boolean hasMissing;
+    private boolean isEqualLength;
 
-    boolean isMultivariate;
-    boolean hasTimeStamps;
+    private boolean isMultivariate;
+    private boolean hasTimeStamps;
 
     // this could be by dimension, so could be a list.
-    int minLength;
-    int maxLength;
-    int maxNumDimensions;
+    private int minLength;
+    private int maxLength;
+    private int maxNumDimensions;
 
+    public int getMaxNumDimensions() {
+        return maxNumDimensions;
+    }
 
-	
     /** 
      * @return String
      */
@@ -160,13 +162,13 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
 
     /* End Meta Information */
 
-    List<TimeSeriesInstance> seriesCollection;
+    private List<TimeSeriesInstance> seriesCollection;
 
     // mapping for class labels. so ["apple","orange"] => [0,1]
     // this could be optional for example regression problems.
-    String[] classLabels;
+    private String[] classLabels;
 
-    int[] classCounts;
+    private int[] classCounts;
 
     public TimeSeriesInstances() {
         seriesCollection = new ArrayList<>();
@@ -177,10 +179,10 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
         setClassLabels(classLabels);
     }
 
-    public TimeSeriesInstances(final List<List<List<Double>>> raw_data) {
+    public TimeSeriesInstances(final List<List<List<Double>>> rawData) {
         this();
 
-        for (final List<List<Double>> series : raw_data) {
+        for (final List<List<Double>> series : rawData) {
             seriesCollection.add(new TimeSeriesInstance(series));
         }
 
@@ -188,22 +190,22 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
     }
 
     
-    public TimeSeriesInstances(final List<List<List<Double>>> raw_data, final List<Double> label_indexes) {
+    public TimeSeriesInstances(final List<List<List<Double>>> rawData, final List<Double> labelIndexes) {
         this();
 
         int index = 0;
-        for (final List<List<Double>> series : raw_data) {
+        for (final List<List<Double>> series : rawData) {
             //using the add function means all stats should be correctly counted.
-            seriesCollection.add(new TimeSeriesInstance(series, label_indexes.get(index++)));
+            seriesCollection.add(new TimeSeriesInstance(series, labelIndexes.get(index++)));
         }
 
         dataChecks();
     }
 
-    public TimeSeriesInstances(final double[][][] raw_data) {
+    public TimeSeriesInstances(final double[][][] rawData) {
         this();
 
-        for (final double[][] series : raw_data) {
+        for (final double[][] series : rawData) {
             //using the add function means all stats should be correctly counted.
             seriesCollection.add(new TimeSeriesInstance(series));
         }
@@ -211,20 +213,20 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
         dataChecks();
     }
 
-    public TimeSeriesInstances(final double[][][] raw_data, int[] label_indexes) {
+    public TimeSeriesInstances(final double[][][] rawData, int[] labelIndexes) {
         this();
 
         int index = 0;
-        for (double[][] series : raw_data) {
+        for (double[][] series : rawData) {
             //using the add function means all stats should be correctly counted.
-            seriesCollection.add(new TimeSeriesInstance(series, label_indexes[index++]));
+            seriesCollection.add(new TimeSeriesInstance(series, labelIndexes[index++]));
         }
 
         dataChecks();
     }
 
-    public TimeSeriesInstances(final double[][][] raw_data, int[] label_indexes, String[] labels) {
-        this(raw_data, label_indexes);
+    public TimeSeriesInstances(final double[][][] rawData, int[] labelIndexes, String[] labels) {
+        this(rawData, labelIndexes);
         classLabels = labels;
     }
 

--- a/src/main/java/tsml/data_containers/TimeSeriesInstances.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstances.java
@@ -501,17 +501,7 @@ public class TimeSeriesInstances extends AbstractList<TimeSeriesInstance> {
     public int numInstances() {
 		return seriesCollection.size();
     }
-
     
-    /** 
-     * @return int
-     */
-    @Override
-    public int hashCode(){
-        return this.seriesCollection.hashCode();
-    }
-
-
     public Map<Integer, Integer> getHistogramOfLengths(){
         Map<Integer, Integer> out = new TreeMap<>();
         for(TimeSeriesInstance inst : seriesCollection){

--- a/src/main/java/tsml/data_containers/TimeSeriesInstances.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstances.java
@@ -249,13 +249,13 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
     private void calculateClassCounts() {
         classCounts = new int[classLabels.length];
         for(TimeSeriesInstance inst : seriesCollection){
-            classCounts[inst.classLabelIndex]++;
+            classCounts[inst.getClassLabelIndex()]++;
         }
     }
 
     private void calculateLengthBounds() {
-        minLength = seriesCollection.stream().mapToInt(e -> e.minLength).min().getAsInt();
-        maxLength = seriesCollection.stream().mapToInt(e -> e.maxLength).max().getAsInt();
+        minLength = seriesCollection.stream().mapToInt(TimeSeriesInstance::getMinLength).min().getAsInt();
+        maxLength = seriesCollection.stream().mapToInt(TimeSeriesInstance::getMaxLength).max().getAsInt();
         isEqualLength = minLength == maxLength;
     }
 
@@ -264,12 +264,12 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
     }
     
     private void calculateIfMultivariate(){
-        isMultivariate = seriesCollection.stream().map(e -> e.isMultivariate).anyMatch(Boolean::booleanValue);
+        isMultivariate = seriesCollection.stream().map(TimeSeriesInstance::isMultivariate).anyMatch(Boolean::booleanValue);
     }
 
     private void calculateIfMissing() {
         // if any of the instance have a missing value then this is true.
-        hasMissing = seriesCollection.stream().map(e -> e.hasMissing).anyMatch(Boolean::booleanValue);
+        hasMissing = seriesCollection.stream().map(TimeSeriesInstance::hasMissing).anyMatch(Boolean::booleanValue);
     }
 
     
@@ -317,15 +317,15 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
         seriesCollection.add(new_series);
 
         //guard for if we're going to force update classCounts after.
-        if(classCounts != null && new_series.classLabelIndex < classCounts.length)
-            classCounts[new_series.classLabelIndex]++;
+        if(classCounts != null && new_series.getClassLabelIndex() < classCounts.length)
+            classCounts[new_series.getClassLabelIndex()]++;
 
-        minLength = Math.min(new_series.minLength, minLength);
-        maxLength = Math.max(new_series.maxLength, maxLength);
+        minLength = Math.min(new_series.getMinLength(), minLength);
+        maxLength = Math.max(new_series.getMaxLength(), maxLength);
         maxNumDimensions = Math.max(new_series.getNumDimensions(), maxNumDimensions);
-        hasMissing |= new_series.hasMissing;
+        hasMissing |= new_series.hasMissing();
         isEqualLength = minLength == maxLength;
-        isMultivariate |= new_series.isMultivariate;
+        isMultivariate |= new_series.isMultivariate();
     }
 
     
@@ -382,7 +382,7 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
         int[] out = new int[numInstances()];
         int index=0;
         for(TimeSeriesInstance inst : seriesCollection){
-            out[index++] = inst.classLabelIndex;
+            out[index++] = inst.getClassLabelIndex();
         }
         return out;
     }

--- a/src/main/java/tsml/data_containers/TimeSeriesInstances.java
+++ b/src/main/java/tsml/data_containers/TimeSeriesInstances.java
@@ -1,18 +1,13 @@
 package tsml.data_containers;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
  * Data structure able to handle unequal length, unequally spaced, univariate or
  * multivariate time series.
  */
-public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
+public class TimeSeriesInstances extends AbstractList<TimeSeriesInstance> {
 
     /* Meta Information */
     private String description;
@@ -290,8 +285,8 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
     /** 
      * @param newSeries
      */
-    public void add(final TimeSeriesInstance newSeries) {
-        seriesCollection.add(newSeries);
+    public void add(int i, final TimeSeriesInstance newSeries) {
+        seriesCollection.add(i, newSeries);
 
         //guard for if we're going to force update classCounts after.
         if(classCounts != null && newSeries.getLabelIndex() < classCounts.length)
@@ -538,5 +533,19 @@ public class TimeSeriesInstances implements Iterable<TimeSeriesInstance> {
         return out;
     }
 
-    
+    @Override public TimeSeriesInstance set(final int i, final TimeSeriesInstance instance) {
+        throw new UnsupportedOperationException("TimeSeriesInstances not mutable");
+    }
+
+    @Override public TimeSeriesInstance remove(final int i) {
+        throw new UnsupportedOperationException("TimeSeriesInstances not mutable");
+    }
+
+    @Override public void clear() {
+        throw new UnsupportedOperationException("TimeSeriesInstances not mutable");
+    }
+
+    @Override public int size() {
+        return numInstances();
+    }
 }

--- a/src/main/java/tsml/data_containers/ts_fileIO/TSReader.java
+++ b/src/main/java/tsml/data_containers/ts_fileIO/TSReader.java
@@ -71,7 +71,7 @@ public class TSReader {
         m_data = new TimeSeriesInstances(raw_data, raw_labels);
         m_data.setClassLabels(classLabels.toArray(new String[classLabels.size()]));
         m_data.setProblemName(problemName);
-        m_data.setHasTimeStamps(timeStamps);
+//        m_data.setHasTimeStamps(timeStamps); // todo this has been temp removed, should be computed from the data
         m_data.setDescription(description);
     }
 

--- a/src/main/java/tsml/data_containers/utilities/TimeSeriesSummaryStatistics.java
+++ b/src/main/java/tsml/data_containers/utilities/TimeSeriesSummaryStatistics.java
@@ -1,10 +1,8 @@
 package tsml.data_containers.utilities;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.DoubleStream;
-import java.util.stream.Stream;
 
 import tsml.data_containers.TimeSeries;
 
@@ -457,7 +455,7 @@ public class TimeSeriesSummaryStatistics {
      * @return TimeSeries
      */
     public static TimeSeries intervalNorm(TimeSeries ts, double min, double max){
-        return new TimeSeries(intervalNorm(ts.toArray(), min, max));
+        return new TimeSeries(intervalNorm(ts.toValuesArray(), min, max));
     }
 
     
@@ -494,7 +492,7 @@ public class TimeSeriesSummaryStatistics {
      * @return TimeSeries
      */
     public static TimeSeries standardNorm(TimeSeries ts, double mean, double std){
-        return new TimeSeries(standardNorm(ts.toArray(), mean, std));
+        return new TimeSeries(standardNorm(ts.toValuesArray(), mean, std));
     }
 
     
@@ -505,7 +503,7 @@ public class TimeSeriesSummaryStatistics {
     public static TimeSeries standardNorm(TimeSeries ts){
         double mean = mean(ts);
         double std = Math.sqrt(variance(ts, mean));
-        return new TimeSeries(standardNorm(ts.toArray(), mean, std));
+        return new TimeSeries(standardNorm(ts.toValuesArray(), mean, std));
     }
 
     

--- a/src/main/java/tsml/data_containers/utilities/TimeSeriesSummaryStatistics.java
+++ b/src/main/java/tsml/data_containers/utilities/TimeSeriesSummaryStatistics.java
@@ -455,7 +455,7 @@ public class TimeSeriesSummaryStatistics {
      * @return TimeSeries
      */
     public static TimeSeries intervalNorm(TimeSeries ts, double min, double max){
-        return new TimeSeries(intervalNorm(ts.toValuesArray(), min, max));
+        return new TimeSeries(intervalNorm(ts.toValueArray(), min, max));
     }
 
     
@@ -492,7 +492,7 @@ public class TimeSeriesSummaryStatistics {
      * @return TimeSeries
      */
     public static TimeSeries standardNorm(TimeSeries ts, double mean, double std){
-        return new TimeSeries(standardNorm(ts.toValuesArray(), mean, std));
+        return new TimeSeries(standardNorm(ts.toValueArray(), mean, std));
     }
 
     
@@ -503,7 +503,7 @@ public class TimeSeriesSummaryStatistics {
     public static TimeSeries standardNorm(TimeSeries ts){
         double mean = mean(ts);
         double std = Math.sqrt(variance(ts, mean));
-        return new TimeSeries(standardNorm(ts.toValuesArray(), mean, std));
+        return new TimeSeries(standardNorm(ts.toValueArray(), mean, std));
     }
 
     

--- a/src/main/java/tsml/graphs/Pipeline.java
+++ b/src/main/java/tsml/graphs/Pipeline.java
@@ -367,7 +367,7 @@ public class Pipeline extends EnhancedAbstractClassifier {
             for(int j=0; j< data.numInstances(); j++){
                 double[][] output1 = new double[1][data.get(j).getMaxLength()];
                 for(int i=0; i<data.get(j).getMaxLength(); i++){
-                    output1[0][i] = TimeSeriesSummaryStatistics.mean(data.get(j).getSingleVSliceArray(i));
+                    output1[0][i] = TimeSeriesSummaryStatistics.mean(data.get(j).getVSliceArray(i));
                 }
 
                 output[j] = output1;

--- a/src/main/java/tsml/transformers/ACF.java
+++ b/src/main/java/tsml/transformers/ACF.java
@@ -25,15 +25,12 @@ import utilities.InstanceTools;
 
 import java.text.DecimalFormat;
 import java.util.ArrayList;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+
 import weka.core.Attribute;
-import weka.core.Capabilities;
 import weka.core.DenseInstance;
 import weka.core.Instance;
 import weka.core.Instances;
 import weka.core.Utils;
-import weka.filters.*;
 
 /**
  * <!-- globalinfo-start --> Implementation of autocorrelation function as a
@@ -523,7 +520,7 @@ public class ACF implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i = 0;
         for(TimeSeries ts : inst){
-            out[i++] = this.fitAutoCorrelations(ts.toArray());
+            out[i++] = this.fitAutoCorrelations(ts.toValuesArray());
         }
         
         //create a new output instance with the ACF data.

--- a/src/main/java/tsml/transformers/ACF.java
+++ b/src/main/java/tsml/transformers/ACF.java
@@ -520,7 +520,7 @@ public class ACF implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i = 0;
         for(TimeSeries ts : inst){
-            out[i++] = this.fitAutoCorrelations(ts.toValuesArray());
+            out[i++] = this.fitAutoCorrelations(ts.toValueArray());
         }
         
         //create a new output instance with the ACF data.

--- a/src/main/java/tsml/transformers/ARMA.java
+++ b/src/main/java/tsml/transformers/ARMA.java
@@ -14,8 +14,6 @@
  */
 package tsml.transformers;
 
-import weka.filters.*;
-
 import weka.core.Attribute;
 import weka.core.DenseInstance;
 import weka.core.Instance;
@@ -193,7 +191,7 @@ public class ARMA implements Transformer {
                 double[][] out = new double[inst.getNumDimensions()][];
                 int i = 0;
                 for (TimeSeries ts : inst) {
-                        out[i++] = calculateValues(ts.toArray());
+                        out[i++] = calculateValues(ts.toValuesArray());
                 }
 
                 // create a new output instance with the ACF data.

--- a/src/main/java/tsml/transformers/ARMA.java
+++ b/src/main/java/tsml/transformers/ARMA.java
@@ -191,7 +191,7 @@ public class ARMA implements Transformer {
                 double[][] out = new double[inst.getNumDimensions()][];
                 int i = 0;
                 for (TimeSeries ts : inst) {
-                        out[i++] = calculateValues(ts.toValuesArray());
+                        out[i++] = calculateValues(ts.toValueArray());
                 }
 
                 // create a new output instance with the ACF data.

--- a/src/main/java/tsml/transformers/AudioFeatures.java
+++ b/src/main/java/tsml/transformers/AudioFeatures.java
@@ -44,7 +44,7 @@ public class AudioFeatures implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i = 0;
         for (TimeSeries ts : inst) {
-            out[i++] = audioTransform(ts.toValuesArray());
+            out[i++] = audioTransform(ts.toValueArray());
         }
 
         // create a new output instance with the ACF data.

--- a/src/main/java/tsml/transformers/AudioFeatures.java
+++ b/src/main/java/tsml/transformers/AudioFeatures.java
@@ -12,7 +12,6 @@ import weka.core.Attribute;
 import weka.core.DenseInstance;
 import weka.core.Instance;
 import weka.core.Instances;
-import weka.filters.SimpleBatchFilter;
 
 import java.util.ArrayList;
 
@@ -45,7 +44,7 @@ public class AudioFeatures implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i = 0;
         for (TimeSeries ts : inst) {
-            out[i++] = audioTransform(ts.toArray());
+            out[i++] = audioTransform(ts.toValuesArray());
         }
 
         // create a new output instance with the ACF data.

--- a/src/main/java/tsml/transformers/Catch22.java
+++ b/src/main/java/tsml/transformers/Catch22.java
@@ -89,7 +89,7 @@ public class Catch22 implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i = 0;
         for(TimeSeries ts : inst){
-            out[i++] = transform(ts.toArray());
+            out[i++] = transform(ts.toValuesArray());
         }
         
         //create a new output instance with the ACF data.

--- a/src/main/java/tsml/transformers/Catch22.java
+++ b/src/main/java/tsml/transformers/Catch22.java
@@ -89,7 +89,7 @@ public class Catch22 implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i = 0;
         for(TimeSeries ts : inst){
-            out[i++] = transform(ts.toValuesArray());
+            out[i++] = transform(ts.toValueArray());
         }
         
         //create a new output instance with the ACF data.

--- a/src/main/java/tsml/transformers/Clipping.java
+++ b/src/main/java/tsml/transformers/Clipping.java
@@ -70,7 +70,7 @@ public class Clipping implements Transformer {
 		int i = 0;
 		for(TimeSeries ts : inst){
 			double mean = TimeSeriesStatsTools.mean(ts);
-			out[i++] = ts.stream().map(e -> e < mean ? 0.0 : 1.0).toArray();
+			out[i++] = ts.streamValues().map(e -> e < mean ? 0.0 : 1.0).toArray();
 		}
 		
 		//create a new output instance with the ACF data.

--- a/src/main/java/tsml/transformers/ColumnNormalizer.java
+++ b/src/main/java/tsml/transformers/ColumnNormalizer.java
@@ -182,7 +182,7 @@ public class ColumnNormalizer implements TrainableTransformer {
 	public double[][] intervalNorm(TimeSeriesInstance r) {
 		double[][] out = new double[r.getMaxLength()][];
 		for (int j = 0; j < r.getMaxLength(); j++) {
-			out[j] = TimeSeriesSummaryStatistics.intervalNorm(r.getSingleVSliceArray(j), min[j], max[j]);
+			out[j] = TimeSeriesSummaryStatistics.intervalNorm(r.getVSliceArray(j), min[j], max[j]);
 		}
 
 		return out;
@@ -195,7 +195,7 @@ public class ColumnNormalizer implements TrainableTransformer {
 		for(int i=0; i<r.numInstances(); i++){
 			out[index] =  new double[r.getMaxLength()][];
 			for (int j = 0; j < r.getMaxLength(); j++) {
-				out[index][j] = TimeSeriesSummaryStatistics.standardNorm(r.get(i).getSingleVSliceArray(j), mean[j], stdev[j]);
+				out[index][j] = TimeSeriesSummaryStatistics.standardNorm(r.get(i).getVSliceArray(j), mean[j], stdev[j]);
 			}
 			out[index++] = ArrayUtilities.transposeMatrix(out[index]);
 		}

--- a/src/main/java/tsml/transformers/ConstantAttributeRemover.java
+++ b/src/main/java/tsml/transformers/ConstantAttributeRemover.java
@@ -2,8 +2,6 @@ package tsml.transformers;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 import tsml.data_containers.TimeSeries;
 import tsml.data_containers.TimeSeriesInstance;
@@ -46,7 +44,7 @@ public class ConstantAttributeRemover implements TrainableTransformer {
 
     private boolean isAttributeConstant(final TimeSeriesInstances data, final int attToCheck){
         //in the first series, in the first dimension, get the att to check.
-        final double firstVal = data.get(0).get(0).get(attToCheck);
+        final double firstVal = data.get(0).get(0).getValue(attToCheck);
         int count =0;
         for(TimeSeriesInstance inst : data){
             for(TimeSeries ts : inst){
@@ -55,7 +53,7 @@ public class ConstantAttributeRemover implements TrainableTransformer {
                 if(ts.hasValidValueAt(attToCheck))
                     continue;
 
-                if (!NumUtils.isNearlyEqual(firstVal, ts.get(attToCheck))) 
+                if (!NumUtils.isNearlyEqual(firstVal, ts.getValue(attToCheck))) 
                     return false;
                 else
                     count++;

--- a/src/main/java/tsml/transformers/ConstantAttributeRemover.java
+++ b/src/main/java/tsml/transformers/ConstantAttributeRemover.java
@@ -89,7 +89,7 @@ public class ConstantAttributeRemover implements TrainableTransformer {
         
         List<List<Double>> out = new ArrayList<>();
         for(TimeSeries ts : inst){
-            out.add(ts.toListWithoutIndexes(indexesToRemove));
+            out.add(ts.getVSliceComplementList(indexesToRemove));
         }
 
         return new TimeSeriesInstance(out);

--- a/src/main/java/tsml/transformers/Convolution.java
+++ b/src/main/java/tsml/transformers/Convolution.java
@@ -69,7 +69,7 @@ public class Convolution implements Transformer {
             out = new double[inst.getNumDimensions()][];
             int i = 0;
             for (TimeSeries ts : inst) {
-                out[i++] = convolution1D(ts.toArray());
+                out[i++] = convolution1D(ts.toValuesArray());
             }
         }
         else{

--- a/src/main/java/tsml/transformers/Convolution.java
+++ b/src/main/java/tsml/transformers/Convolution.java
@@ -69,7 +69,7 @@ public class Convolution implements Transformer {
             out = new double[inst.getNumDimensions()][];
             int i = 0;
             for (TimeSeries ts : inst) {
-                out[i++] = convolution1D(ts.toValuesArray());
+                out[i++] = convolution1D(ts.toValueArray());
             }
         }
         else{

--- a/src/main/java/tsml/transformers/Cosine.java
+++ b/src/main/java/tsml/transformers/Cosine.java
@@ -15,12 +15,10 @@
 package tsml.transformers;
 
 import java.io.File;
-import java.util.Arrays;
 
 import experiments.data.DatasetLoading;
 import tsml.data_containers.TimeSeries;
 import tsml.data_containers.TimeSeriesInstance;
-import utilities.InstanceTools;
 import weka.core.*;
 
 /*
@@ -43,7 +41,7 @@ public class Cosine implements Transformer {
                 double fk = 0;
                 for (int i = 0; i < n; i++) {
                     double c = k * (i + 0.5) * (Math.PI / n);
-                    fk += ts.get(i) * Math.cos(c);
+                    fk += ts.getValue(i) * Math.cos(c);
                 }
                 data[k] = fk;
             }

--- a/src/main/java/tsml/transformers/DWT.java
+++ b/src/main/java/tsml/transformers/DWT.java
@@ -153,7 +153,7 @@ public class DWT implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i = 0;
         for(TimeSeries ts : inst){
-            out[i++] = getDWTCoefficients(ts.toValuesArray());
+            out[i++] = getDWTCoefficients(ts.toValueArray());
         }
         
         //create a new output instance with the ACF data.

--- a/src/main/java/tsml/transformers/DWT.java
+++ b/src/main/java/tsml/transformers/DWT.java
@@ -153,7 +153,7 @@ public class DWT implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i = 0;
         for(TimeSeries ts : inst){
-            out[i++] = getDWTCoefficients(ts.toArray());
+            out[i++] = getDWTCoefficients(ts.toValuesArray());
         }
         
         //create a new output instance with the ACF data.

--- a/src/main/java/tsml/transformers/Derivative.java
+++ b/src/main/java/tsml/transformers/Derivative.java
@@ -94,7 +94,7 @@ public class Derivative implements Transformer, Serializable {
         double[][] out = new double[inst.getNumDimensions()][];
         int i = 0;
         for (TimeSeries ts : inst) {
-            out[i++] = getDerivative(ts.toValuesArray(), false);
+            out[i++] = getDerivative(ts.toValueArray(), false);
         }
 
         return new TimeSeriesInstance(out, inst.getLabelIndex());

--- a/src/main/java/tsml/transformers/Derivative.java
+++ b/src/main/java/tsml/transformers/Derivative.java
@@ -94,7 +94,7 @@ public class Derivative implements Transformer, Serializable {
         double[][] out = new double[inst.getNumDimensions()][];
         int i = 0;
         for (TimeSeries ts : inst) {
-            out[i++] = getDerivative(ts.toArray(), false);
+            out[i++] = getDerivative(ts.toValuesArray(), false);
         }
 
         return new TimeSeriesInstance(out, inst.getLabelIndex());

--- a/src/main/java/tsml/transformers/Differences.java
+++ b/src/main/java/tsml/transformers/Differences.java
@@ -127,7 +127,7 @@ public class Differences implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i = 0;
         for (TimeSeries ts : inst) {
-            out[i++] = calculateDifferences(ts.toArray(), ts.getSeriesLength() - order);
+            out[i++] = calculateDifferences(ts.toValuesArray(), ts.getSeriesLength() - order);
         }
 
         return new TimeSeriesInstance(out, inst.getLabelIndex());

--- a/src/main/java/tsml/transformers/Differences.java
+++ b/src/main/java/tsml/transformers/Differences.java
@@ -127,7 +127,7 @@ public class Differences implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i = 0;
         for (TimeSeries ts : inst) {
-            out[i++] = calculateDifferences(ts.toValuesArray(), ts.getSeriesLength() - order);
+            out[i++] = calculateDifferences(ts.toValueArray(), ts.getSeriesLength() - order);
         }
 
         return new TimeSeriesInstance(out, inst.getLabelIndex());

--- a/src/main/java/tsml/transformers/FFT.java
+++ b/src/main/java/tsml/transformers/FFT.java
@@ -14,8 +14,6 @@
  */
 package tsml.transformers;
 
-import java.util.Arrays;
-
 import tsml.data_containers.TimeSeries;
 import tsml.data_containers.TimeSeriesInstance;
 /* Performs a FFT of the data set. NOTE:
@@ -290,8 +288,8 @@ public class FFT implements Transformer {
 			int count = 0;
 			double seriesTotal = 0;
 			for (int j = 0; j < ts.getSeriesLength() && count < c.length; j++) { // May cut off the trailing values
-				c[count] = new Complex(ts.get(j), 0.0);
-				seriesTotal += ts.get(j);
+				c[count] = new Complex(ts.getValue(j), 0.0);
+				seriesTotal += ts.getValue(j);
 				count++;
 			}
 			// Add any Padding required

--- a/src/main/java/tsml/transformers/Fast_FFT.java
+++ b/src/main/java/tsml/transformers/Fast_FFT.java
@@ -125,7 +125,7 @@ public class Fast_FFT implements Transformer {
         int i = 0;
         for (TimeSeries ts : inst) {
             //TODO: make this NaN Safe. Mean is NaN safe but toArray isnt.
-            out[i++] = calculate_FFT(ts.toValuesArray(), TimeSeriesSummaryStatistics.mean(ts));
+            out[i++] = calculate_FFT(ts.toValueArray(), TimeSeriesSummaryStatistics.mean(ts));
         }
         return new TimeSeriesInstance(out, inst.getLabelIndex()); 
     }

--- a/src/main/java/tsml/transformers/Fast_FFT.java
+++ b/src/main/java/tsml/transformers/Fast_FFT.java
@@ -10,10 +10,8 @@ import org.apache.commons.math3.transform.DftNormalization;
 import org.apache.commons.math3.transform.FastFourierTransformer;
 import org.apache.commons.math3.transform.TransformType;
 import weka.core.*;
-import weka.filters.SimpleBatchFilter;
 
 import static experiments.data.DatasetLoading.loadDataNullable;
-import static utilities.InstanceTools.fromWekaInstancesArray;
 
 public class Fast_FFT implements Transformer {
     final String className = "sandbox.transforms.FFT";
@@ -127,7 +125,7 @@ public class Fast_FFT implements Transformer {
         int i = 0;
         for (TimeSeries ts : inst) {
             //TODO: make this NaN Safe. Mean is NaN safe but toArray isnt.
-            out[i++] = calculate_FFT(ts.toArray(), TimeSeriesSummaryStatistics.mean(ts));
+            out[i++] = calculate_FFT(ts.toValuesArray(), TimeSeriesSummaryStatistics.mean(ts));
         }
         return new TimeSeriesInstance(out, inst.getLabelIndex()); 
     }

--- a/src/main/java/tsml/transformers/HOG1D.java
+++ b/src/main/java/tsml/transformers/HOG1D.java
@@ -140,7 +140,7 @@ public class HOG1D implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i =0;
         for(TimeSeries ts : inst){
-            out[i++] = getHOG1Ds(ts.toValuesArray());
+            out[i++] = getHOG1Ds(ts.toValueArray());
         }
 
         return new TimeSeriesInstance(out, inst.getLabelIndex());

--- a/src/main/java/tsml/transformers/HOG1D.java
+++ b/src/main/java/tsml/transformers/HOG1D.java
@@ -140,7 +140,7 @@ public class HOG1D implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i =0;
         for(TimeSeries ts : inst){
-            out[i++] = getHOG1Ds(ts.toArray());
+            out[i++] = getHOG1Ds(ts.toValuesArray());
         }
 
         return new TimeSeriesInstance(out, inst.getLabelIndex());

--- a/src/main/java/tsml/transformers/Hilbert.java
+++ b/src/main/java/tsml/transformers/Hilbert.java
@@ -102,7 +102,7 @@ public class Hilbert implements Transformer {
 				double fk = 0;
 				for (int i = 0; i < n; i++) {
 					if (i != k)
-						fk += ts.get(i) / (k - i);
+						fk += ts.getValue(i) / (k - i);
 				}
 				out[index][k] = fk;
 			}

--- a/src/main/java/tsml/transformers/MatrixProfile.java
+++ b/src/main/java/tsml/transformers/MatrixProfile.java
@@ -82,7 +82,7 @@ public class MatrixProfile implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i = 0;
         for (TimeSeries ts : inst) {
-            out[i++] = new SingleInstanceMatrixProfile(ts.toValuesArray(), this.windowSize, this.stride).series;
+            out[i++] = new SingleInstanceMatrixProfile(ts.toValueArray(), this.windowSize, this.stride).series;
         }
         return new TimeSeriesInstance(out, inst.getLabelIndex()); 
     }

--- a/src/main/java/tsml/transformers/MatrixProfile.java
+++ b/src/main/java/tsml/transformers/MatrixProfile.java
@@ -82,7 +82,7 @@ public class MatrixProfile implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i = 0;
         for (TimeSeries ts : inst) {
-            out[i++] = new SingleInstanceMatrixProfile(ts.toArray(), this.windowSize, this.stride).series;
+            out[i++] = new SingleInstanceMatrixProfile(ts.toValuesArray(), this.windowSize, this.stride).series;
         }
         return new TimeSeriesInstance(out, inst.getLabelIndex()); 
     }

--- a/src/main/java/tsml/transformers/PAA.java
+++ b/src/main/java/tsml/transformers/PAA.java
@@ -22,7 +22,6 @@ import weka.core.Attribute;
 import weka.core.DenseInstance;
 import weka.core.Instance;
 import weka.core.Instances;
-import weka.filters.SimpleBatchFilter;
 
 /**
  * Filter to reduce dimensionality of a time series into Piecewise Aggregate
@@ -106,7 +105,7 @@ public class PAA implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i =0;
         for(TimeSeries ts : inst){
-            out[i++] = convertInstance(ts.toArray());
+            out[i++] = convertInstance(ts.toValuesArray());
         }
 
         return new TimeSeriesInstance(out, inst.getLabelIndex());

--- a/src/main/java/tsml/transformers/PAA.java
+++ b/src/main/java/tsml/transformers/PAA.java
@@ -105,7 +105,7 @@ public class PAA implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i =0;
         for(TimeSeries ts : inst){
-            out[i++] = convertInstance(ts.toValuesArray());
+            out[i++] = convertInstance(ts.toValueArray());
         }
 
         return new TimeSeriesInstance(out, inst.getLabelIndex());

--- a/src/main/java/tsml/transformers/PACF.java
+++ b/src/main/java/tsml/transformers/PACF.java
@@ -20,10 +20,8 @@ import tsml.data_containers.TSCapabilities;
 import tsml.data_containers.TimeSeries;
 import tsml.data_containers.TimeSeriesInstance;
 import utilities.InstanceTools;
-import weka.filters.*;
 
 import weka.core.Attribute;
-import weka.core.Capabilities;
 import weka.core.DenseInstance;
 import weka.core.Instance;
 import weka.core.Instances;
@@ -144,7 +142,7 @@ public class PACF implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i =0;
         for(TimeSeries ts : inst){
-            out[i++] = convertInstance(ts.toArray());
+            out[i++] = convertInstance(ts.toValuesArray());
         }
 
         return new TimeSeriesInstance(out, inst.getLabelIndex());

--- a/src/main/java/tsml/transformers/PACF.java
+++ b/src/main/java/tsml/transformers/PACF.java
@@ -142,7 +142,7 @@ public class PACF implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i =0;
         for(TimeSeries ts : inst){
-            out[i++] = convertInstance(ts.toValuesArray());
+            out[i++] = convertInstance(ts.toValueArray());
         }
 
         return new TimeSeriesInstance(out, inst.getLabelIndex());

--- a/src/main/java/tsml/transformers/PowerSpectrum.java
+++ b/src/main/java/tsml/transformers/PowerSpectrum.java
@@ -129,13 +129,13 @@ public class PowerSpectrum extends FFT {
             if(log){
                 double l1;		
                 for(int j=0;j<length;j++){
-                    l1= Math.sqrt(f.get(j*2)*f.get(j*2)+f.get(j*2+1)*f.get(j*2+1));
+                    l1= Math.sqrt(f.getValue(j*2)*f.getValue(j*2)+f.getValue(j*2+1)*f.getValue(j*2+1));
                     vals.set(j,Math.log(l1));
                 }
             }
             else{
                 for (int j = 0; j < length; j++) {
-                    vals.set(j, Math.sqrt(f.get(j * 2) * f.get(j * 2) + f.get(j * 2 + 1) * f.get(j * 2 + 1)));
+                    vals.set(j, Math.sqrt(f.getValue(j * 2) * f.getValue(j * 2) + f.getValue(j * 2 + 1) * f.getValue(j * 2 + 1)));
                 }
             }
 

--- a/src/main/java/tsml/transformers/Resizer.java
+++ b/src/main/java/tsml/transformers/Resizer.java
@@ -192,7 +192,7 @@ public class Resizer implements TrainableTransformer {
         int i=0;
         for(TimeSeries ts : inst){
             int diff = resizeLength - ts.getSeriesLength(); 
-            double[] data = ts.toValuesArray();
+            double[] data = ts.toValueArray();
 
             // just need to copy data across, if we're the same or longer. truncate the
             // first values.

--- a/src/main/java/tsml/transformers/Resizer.java
+++ b/src/main/java/tsml/transformers/Resizer.java
@@ -14,7 +14,6 @@ import tsml.data_containers.TimeSeriesInstances;
 import tsml.data_containers.utilities.TimeSeriesSummaryStatistics;
 import utilities.ClassifierTools;
 import utilities.InstanceTools;
-import weka.classifiers.meta.RotationForest;
 import weka.core.Attribute;
 import weka.core.DenseInstance;
 import weka.core.Instance;
@@ -193,7 +192,7 @@ public class Resizer implements TrainableTransformer {
         int i=0;
         for(TimeSeries ts : inst){
             int diff = resizeLength - ts.getSeriesLength(); 
-            double[] data = ts.toArray();
+            double[] data = ts.toValuesArray();
 
             // just need to copy data across, if we're the same or longer. truncate the
             // first values.

--- a/src/main/java/tsml/transformers/RowNormalizer.java
+++ b/src/main/java/tsml/transformers/RowNormalizer.java
@@ -288,7 +288,7 @@ public class RowNormalizer implements Transformer {
 	}
 
 	public static TimeSeries standardNorm(TimeSeries ts) {
-		double[] out = ts.toValuesArray(); //this is a copy.
+		double[] out = ts.toValueArray(); //this is a copy.
 
 		double mean = TimeSeriesSummaryStatistics.mean(out);
 		double var = TimeSeriesSummaryStatistics.variance(ts, mean);
@@ -312,7 +312,7 @@ public class RowNormalizer implements Transformer {
 
 
 	public static TimeSeries standard(TimeSeries ts){
-		double[] out = ts.toValuesArray(); //this is a copy.
+		double[] out = ts.toValueArray(); //this is a copy.
 
 		double mean = TimeSeriesSummaryStatistics.mean(out);
 
@@ -324,7 +324,7 @@ public class RowNormalizer implements Transformer {
 	}
 
 	public static TimeSeries intervalNorm(TimeSeries ts){
-		double[] out = ts.toValuesArray(); //this is a copy.
+		double[] out = ts.toValueArray(); //this is a copy.
 
 		double max = TimeSeriesSummaryStatistics.max(out);
 		double min =  TimeSeriesSummaryStatistics.min(out);

--- a/src/main/java/tsml/transformers/RowNormalizer.java
+++ b/src/main/java/tsml/transformers/RowNormalizer.java
@@ -288,7 +288,7 @@ public class RowNormalizer implements Transformer {
 	}
 
 	public static TimeSeries standardNorm(TimeSeries ts) {
-		double[] out = ts.toArray(); //this is a copy.
+		double[] out = ts.toValuesArray(); //this is a copy.
 
 		double mean = TimeSeriesSummaryStatistics.mean(out);
 		double var = TimeSeriesSummaryStatistics.variance(ts, mean);
@@ -312,7 +312,7 @@ public class RowNormalizer implements Transformer {
 
 
 	public static TimeSeries standard(TimeSeries ts){
-		double[] out = ts.toArray(); //this is a copy.
+		double[] out = ts.toValuesArray(); //this is a copy.
 
 		double mean = TimeSeriesSummaryStatistics.mean(out);
 
@@ -324,7 +324,7 @@ public class RowNormalizer implements Transformer {
 	}
 
 	public static TimeSeries intervalNorm(TimeSeries ts){
-		double[] out = ts.toArray(); //this is a copy.
+		double[] out = ts.toValuesArray(); //this is a copy.
 
 		double max = TimeSeriesSummaryStatistics.max(out);
 		double min =  TimeSeriesSummaryStatistics.min(out);

--- a/src/main/java/tsml/transformers/RunLength.java
+++ b/src/main/java/tsml/transformers/RunLength.java
@@ -194,7 +194,7 @@ public class RunLength implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i =0;
         for(TimeSeries ts : inst){
-            out[i++] = create_data(ts.toValuesArray(), useGlobalMean ? globalMean : TimeSeriesSummaryStatistics.mean(ts));
+            out[i++] = create_data(ts.toValueArray(), useGlobalMean ? globalMean : TimeSeriesSummaryStatistics.mean(ts));
         }
 
         return new TimeSeriesInstance(out, inst.getLabelIndex());

--- a/src/main/java/tsml/transformers/RunLength.java
+++ b/src/main/java/tsml/transformers/RunLength.java
@@ -21,7 +21,6 @@ import tsml.data_containers.TimeSeries;
 import tsml.data_containers.TimeSeriesInstance;
 import tsml.data_containers.utilities.TimeSeriesSummaryStatistics;
 import utilities.InstanceTools;
-import weka.filters.*;
 import weka.core.Attribute;
 import weka.core.DenseInstance;
 import weka.core.Instance;
@@ -195,7 +194,7 @@ public class RunLength implements Transformer {
         double[][] out = new double[inst.getNumDimensions()][];
         int i =0;
         for(TimeSeries ts : inst){
-            out[i++] = create_data(ts.toArray(), useGlobalMean ? globalMean : TimeSeriesSummaryStatistics.mean(ts));
+            out[i++] = create_data(ts.toValuesArray(), useGlobalMean ? globalMean : TimeSeriesSummaryStatistics.mean(ts));
         }
 
         return new TimeSeriesInstance(out, inst.getLabelIndex());

--- a/src/main/java/tsml/transformers/SAX.java
+++ b/src/main/java/tsml/transformers/SAX.java
@@ -24,7 +24,6 @@ import weka.core.Instance;
 import weka.core.Instances;
 import weka.core.TechnicalInformation;
 import weka.core.TechnicalInformationHandler;
-import weka.filters.SimpleBatchFilter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -260,7 +259,7 @@ public class SAX implements Transformer, TechnicalInformationHandler {
         double[][] out = new double[inst.getNumDimensions()][];
         int i =0;
         for(TimeSeries ts : inst){
-            double[] o = ts.toArray();
+            double[] o = ts.toValuesArray();
             convertSequence(o);
             out[i++] = o;
         }

--- a/src/main/java/tsml/transformers/SAX.java
+++ b/src/main/java/tsml/transformers/SAX.java
@@ -259,7 +259,7 @@ public class SAX implements Transformer, TechnicalInformationHandler {
         double[][] out = new double[inst.getNumDimensions()][];
         int i =0;
         for(TimeSeries ts : inst){
-            double[] o = ts.toValuesArray();
+            double[] o = ts.toValueArray();
             convertSequence(o);
             out[i++] = o;
         }

--- a/src/main/java/tsml/transformers/Sine.java
+++ b/src/main/java/tsml/transformers/Sine.java
@@ -19,7 +19,6 @@ import java.io.File;
 import experiments.data.DatasetLoading;
 import tsml.data_containers.TimeSeries;
 import tsml.data_containers.TimeSeriesInstance;
-import utilities.InstanceTools;
 import weka.core.*;
 
 /*
@@ -41,7 +40,7 @@ public class Sine implements Transformer {
                 double fk = 0;
                 for (int i = 0; i < n; i++) {
                     double c = k * (i + 0.5) * (Math.PI / n);
-                    fk += ts.get(i) * Math.sin(c);
+                    fk += ts.getValue(i) * Math.sin(c);
                 }
                 data[k] = fk;
             }

--- a/src/main/java/tsml/transformers/Slope.java
+++ b/src/main/java/tsml/transformers/Slope.java
@@ -2,12 +2,11 @@ package tsml.transformers;
 
 import tsml.data_containers.TimeSeries;
 import tsml.data_containers.TimeSeriesInstance;
-import tsml.transformers.Transformer;
 import weka.core.Attribute;
 import weka.core.DenseInstance;
 import weka.core.Instance;
 import weka.core.Instances;
-import experiments.data.DatasetLoading;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -77,7 +76,7 @@ public class Slope implements Transformer {
         int i =0;
         for(TimeSeries ts : inst){
             checkParameters(ts.getSeriesLength());
-            out[i++] = getGradients(ts.toArray());
+            out[i++] = getGradients(ts.toValuesArray());
         }
 
         return new TimeSeriesInstance(out, inst.getLabelIndex());

--- a/src/main/java/tsml/transformers/Slope.java
+++ b/src/main/java/tsml/transformers/Slope.java
@@ -76,7 +76,7 @@ public class Slope implements Transformer {
         int i =0;
         for(TimeSeries ts : inst){
             checkParameters(ts.getSeriesLength());
-            out[i++] = getGradients(ts.toValuesArray());
+            out[i++] = getGradients(ts.toValueArray());
         }
 
         return new TimeSeriesInstance(out, inst.getLabelIndex());

--- a/src/main/java/tsml/transformers/Spectrogram.java
+++ b/src/main/java/tsml/transformers/Spectrogram.java
@@ -115,7 +115,7 @@ public class Spectrogram implements Transformer {
     public TimeSeriesInstance transform(TimeSeriesInstance inst) {
         List<TimeSeries> out = new ArrayList<>();
         for (TimeSeries ts : inst) {
-            double[] signal = ts.toValuesArray();
+            double[] signal = ts.toValueArray();
             double [][] spectrogram = spectrogram(signal, windowLength, overlap, nfft);
 
             for(double[] spec : spectrogram){

--- a/src/main/java/tsml/transformers/Spectrogram.java
+++ b/src/main/java/tsml/transformers/Spectrogram.java
@@ -8,10 +8,8 @@ import org.apache.commons.math3.transform.TransformType;
 
 import tsml.data_containers.TimeSeries;
 import tsml.data_containers.TimeSeriesInstance;
-import tsml.data_containers.TimeSeriesInstances;
 import utilities.multivariate_tools.MultivariateInstanceTools;
 import weka.core.*;
-import weka.filters.SimpleBatchFilter;
 
 import static experiments.data.DatasetLoading.loadDataNullable;
 
@@ -117,7 +115,7 @@ public class Spectrogram implements Transformer {
     public TimeSeriesInstance transform(TimeSeriesInstance inst) {
         List<TimeSeries> out = new ArrayList<>();
         for (TimeSeries ts : inst) {
-            double[] signal = ts.toArray();
+            double[] signal = ts.toValuesArray();
             double [][] spectrogram = spectrogram(signal, windowLength, overlap, nfft);
 
             for(double[] spec : spectrogram){

--- a/src/main/java/tsml/transformers/Subsequences.java
+++ b/src/main/java/tsml/transformers/Subsequences.java
@@ -87,7 +87,7 @@ public class Subsequences implements Transformer {
         int i =0;
         for(TimeSeries ts : inst){
             // Extract the subsequences.
-            double[][] subsequences = extractSubsequences(TimeSeriesSummaryStatistics.standardNorm(ts).toArray());
+            double[][] subsequences = extractSubsequences(TimeSeriesSummaryStatistics.standardNorm(ts).toValuesArray());
             
             //stack subsequences if we're multivariate.
             for(double[] d : subsequences)

--- a/src/main/java/tsml/transformers/Subsequences.java
+++ b/src/main/java/tsml/transformers/Subsequences.java
@@ -87,7 +87,7 @@ public class Subsequences implements Transformer {
         int i =0;
         for(TimeSeries ts : inst){
             // Extract the subsequences.
-            double[][] subsequences = extractSubsequences(TimeSeriesSummaryStatistics.standardNorm(ts).toValuesArray());
+            double[][] subsequences = extractSubsequences(TimeSeriesSummaryStatistics.standardNorm(ts).toValueArray());
             
             //stack subsequences if we're multivariate.
             for(double[] d : subsequences)

--- a/src/main/java/tsml/transformers/shapelet_tools/distance_functions/ShapeletDistance.java
+++ b/src/main/java/tsml/transformers/shapelet_tools/distance_functions/ShapeletDistance.java
@@ -121,7 +121,7 @@ public class ShapeletDistance implements Serializable{
 
         //only call to double array when we've changed series.
         if(candidateTSInst==null || candidateTSInst != inst){
-            candidateArray = inst.get(dimension).toArray();
+            candidateArray = inst.get(dimension).toValuesArray();
             candidateTSInst = inst;
         }
         
@@ -141,7 +141,7 @@ public class ShapeletDistance implements Serializable{
     }
 
     public double calculate(TimeSeriesInstance timeSeriesInstance, int timeSeriesId) {
-		return calculate(timeSeriesInstance.get(dimension).toArray(), timeSeriesId);
+		return calculate(timeSeriesInstance.get(dimension).toValuesArray(), timeSeriesId);
 	}
          
     public double distanceToShapelet(Shapelet otherShapelet){

--- a/src/main/java/tsml/transformers/shapelet_tools/distance_functions/ShapeletDistance.java
+++ b/src/main/java/tsml/transformers/shapelet_tools/distance_functions/ShapeletDistance.java
@@ -121,7 +121,7 @@ public class ShapeletDistance implements Serializable{
 
         //only call to double array when we've changed series.
         if(candidateTSInst==null || candidateTSInst != inst){
-            candidateArray = inst.get(dimension).toValuesArray();
+            candidateArray = inst.get(dimension).toValueArray();
             candidateTSInst = inst;
         }
         
@@ -141,7 +141,7 @@ public class ShapeletDistance implements Serializable{
     }
 
     public double calculate(TimeSeriesInstance timeSeriesInstance, int timeSeriesId) {
-		return calculate(timeSeriesInstance.get(dimension).toValuesArray(), timeSeriesId);
+		return calculate(timeSeriesInstance.get(dimension).toValueArray(), timeSeriesId);
 	}
          
     public double distanceToShapelet(Shapelet otherShapelet){


### PR DESCRIPTION
This includes a bunch of tweaks to the new data structure:

- Vertical slicing and horizontal slicing on all structures
- Privacy modifiers everywhere, any direct access replaced with getters
- Each data structure (`TimeSeries`, `TimeSeriesInstance`, `TimeSeriesInstances`) extends `AbstractList` typed to their corresponding contents, e.g. `TimeSeriesInstances extends AbstractList<TimeSeriesInstance>`
    - This gives neat convenience methods found in `List`s in Java, e.g. `addAll`, `subList`, etc
- Equals methods for all structures
- Removed the setters from the metadata
   - The idea being these are derived from the data inside the structure

All the above helps the new data structures be more usable, but we've got some design decisions to make (see issue #444 ). 
