### PR TITLE
Parameter gathering from ensemble members in more exp modes 

### DIFF
--- a/src/main/java/tsml/classifiers/hybrids/HIVE_COTE.java
+++ b/src/main/java/tsml/classifiers/hybrids/HIVE_COTE.java
@@ -414,16 +414,14 @@ public class HIVE_COTE extends AbstractEnsemble implements TechnicalInformationH
 
     @Override
     public String getParameters() {
-        String str="WeightingScheme,"+weightingScheme+",";//+alpha;
+        String str="WeightingScheme,"+weightingScheme+","+"VotingScheme,"+votingScheme+",";//+alpha;
+
         for (EnsembleModule module : modules)
-            str+=module.posteriorWeights[0]+","+module.getModuleName()+",";
-        for (EnsembleModule module : modules) {
-            if (module.getClassifier() instanceof EnhancedAbstractClassifier)
-                str += ((EnhancedAbstractClassifier) module.getClassifier()).getParameters();
-            else
-                str += "NoParaInfo,";
-            str += ",,";
-        }
+            str+=module.getModuleName()+","+module.posteriorWeights[0]+",";
+
+        for (EnsembleModule module : modules)
+            str += module.getParameters() + ",,";
+
         return str;
 
     }


### PR DESCRIPTION
Abstract ensembles will now look in more places for their member's parameters. Have left in the getParameters override in HIVE_COTE just for familiarity for whoever wrote it